### PR TITLE
Consensus provider migration

### DIFF
--- a/packages/contracts/contracts/consensus/BurnAuction.sol
+++ b/packages/contracts/contracts/consensus/BurnAuction.sol
@@ -6,9 +6,6 @@ import "../zkopru/interfaces/ICoordinatable.sol";
 import "./interfaces/IConsensusProvider.sol";
 import "./interfaces/IBurnAuction.sol";
 
-/**
- * @dev [WIP] Sample contract to implement burn auction for coordination consensus.
- */
 contract BurnAuction is IConsensusProvider, IBurnAuction {
     Zkopru public zkopru;
 
@@ -54,6 +51,11 @@ contract BurnAuction is IConsensusProvider, IBurnAuction {
     constructor(address payable networkAddress) public {
         zkopru = Zkopru(networkAddress);
         startBlock = uint32(block.number);
+    }
+
+    function updateZkopru(address payable newZkopru) public override {
+        require(msg.sender == address(zkopru), "BurnAuction: Invalid caller");
+        zkopru = Zkopru(newZkopru);
     }
 
     function bid(uint roundIndex) public override payable {

--- a/packages/contracts/contracts/consensus/interfaces/IConsensusProvider.sol
+++ b/packages/contracts/contracts/consensus/interfaces/IConsensusProvider.sol
@@ -5,4 +5,5 @@ interface IConsensusProvider {
     function openRoundIfNeeded() external;
     function lockForUpgrade(uint roundIndex) external;
     function isProposable(address proposer) external view returns (bool);
+    function updateZkopru(address payable newZkopru) external;
 }

--- a/packages/contracts/contracts/zkopru/Zkopru.sol
+++ b/packages/contracts/contracts/zkopru/Zkopru.sol
@@ -10,6 +10,7 @@ import { SNARK } from "./libraries/SNARK.sol";
 import { Blockchain, Header, Types } from "./libraries/Types.sol";
 import { Pairing, G1Point, G2Point } from "./libraries/Pairing.sol";
 import { Hash } from "./libraries/Hash.sol";
+import { IConsensusProvider } from "../consensus/interfaces/IConsensusProvider.sol";
 
 contract Zkopru is Proxy, Reader, ISetupWizard {
     using Types for Header;
@@ -110,6 +111,12 @@ contract Zkopru is Proxy, Reader, ISetupWizard {
      */
     function makeMigratable(address addr) public override onlyOwner {
         Proxy._connectMigratable(addr);
+    }
+
+    function migrateConsensusProvider(address payable newZkopru) public override onlyOwner {
+        require(address(consensusProvider) != address(0), "Consensus provider not set");
+        IConsensusProvider consensus = IConsensusProvider(consensusProvider);
+        consensus.updateZkopru(newZkopru);
     }
 
     /**

--- a/packages/contracts/contracts/zkopru/interfaces/ISetupWizard.sol
+++ b/packages/contracts/contracts/zkopru/interfaces/ISetupWizard.sol
@@ -28,6 +28,8 @@ interface ISetupWizard {
         address txValidator
     ) external;
 
+    function migrateConsensusProvider(address payable newZkopru) external;
+
     function makeMigratable(address addr) external;
 
     function allowMigrants(address[] calldata migrants) external;

--- a/packages/contracts/migrations/19_migration_dest.js
+++ b/packages/contracts/migrations/19_migration_dest.js
@@ -73,6 +73,7 @@ module.exports = function migration(deployer, network, accounts) {
     await dest.makeConfigurable(instances.configurable.address)
     const configurable = await Configurable.at(dest.address)
     await configurable.setConsensusProvider(instances.burnAuction.address)
+    await source.migrateConsensusProvider(dest.address)
     // Setup zkSNARKs
     // Setup migrations
     const keyDir = path.join(__dirname, '../keys/vks')

--- a/packages/contracts/src/abis/BurnAuction.ts
+++ b/packages/contracts/src/abis/BurnAuction.ts
@@ -129,6 +129,15 @@ export const BurnAuctionABI = [
     type: 'function',
   },
   {
+    inputs: [
+      { internalType: 'address payable', name: 'newZkopru', type: 'address' },
+    ],
+    name: 'updateZkopru',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
     inputs: [{ internalType: 'uint256', name: 'roundIndex', type: 'uint256' }],
     name: 'bid',
     outputs: [],

--- a/packages/contracts/src/abis/IConsensusProvider.ts
+++ b/packages/contracts/src/abis/IConsensusProvider.ts
@@ -20,4 +20,13 @@ export const IConsensusProviderABI = [
     stateMutability: 'view',
     type: 'function',
   },
+  {
+    inputs: [
+      { internalType: 'address payable', name: 'newZkopru', type: 'address' },
+    ],
+    name: 'updateZkopru',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
 ]

--- a/packages/contracts/src/abis/ISetupWizard.ts
+++ b/packages/contracts/src/abis/ISetupWizard.ts
@@ -107,6 +107,15 @@ export const ISetupWizardABI = [
     type: 'function',
   },
   {
+    inputs: [
+      { internalType: 'address payable', name: 'newZkopru', type: 'address' },
+    ],
+    name: 'migrateConsensusProvider',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
     inputs: [{ internalType: 'address', name: 'addr', type: 'address' }],
     name: 'makeMigratable',
     outputs: [],

--- a/packages/contracts/src/abis/Zkopru.ts
+++ b/packages/contracts/src/abis/Zkopru.ts
@@ -471,6 +471,15 @@ export const ZkopruABI = [
   },
   {
     inputs: [
+      { internalType: 'address payable', name: 'newZkopru', type: 'address' },
+    ],
+    name: 'migrateConsensusProvider',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
       { internalType: 'address[]', name: 'migrants', type: 'address[]' },
     ],
     name: 'allowMigrants',

--- a/packages/contracts/src/contracts/BurnAuction.d.ts
+++ b/packages/contracts/src/contracts/BurnAuction.d.ts
@@ -48,6 +48,8 @@ export class BurnAuction extends Contract {
 
     zkopru(): TransactionObject<string>
 
+    updateZkopru(newZkopru: string): TransactionObject<void>
+
     bid(roundIndex: number | string): TransactionObject<void>
 
     multiBid(

--- a/packages/contracts/src/contracts/IConsensusProvider.d.ts
+++ b/packages/contracts/src/contracts/IConsensusProvider.d.ts
@@ -24,6 +24,8 @@ export class IConsensusProvider extends Contract {
     lockForUpgrade(roundIndex: number | string): TransactionObject<void>
 
     isProposable(proposer: string): TransactionObject<boolean>
+
+    updateZkopru(newZkopru: string): TransactionObject<void>
   }
 
   events: {

--- a/packages/contracts/src/contracts/ISetupWizard.d.ts
+++ b/packages/contracts/src/contracts/ISetupWizard.d.ts
@@ -48,6 +48,8 @@ export class ISetupWizard extends Contract {
       txValidator: string,
     ): TransactionObject<void>
 
+    migrateConsensusProvider(newZkopru: string): TransactionObject<void>
+
     makeMigratable(addr: string): TransactionObject<void>
 
     allowMigrants(migrants: string[]): TransactionObject<void>

--- a/packages/contracts/src/contracts/Zkopru.d.ts
+++ b/packages/contracts/src/contracts/Zkopru.d.ts
@@ -169,6 +169,8 @@ export class Zkopru extends Contract {
 
     makeMigratable(addr: string): TransactionObject<void>
 
+    migrateConsensusProvider(newZkopru: string): TransactionObject<void>
+
     allowMigrants(migrants: string[]): TransactionObject<void>
 
     completeSetup(): TransactionObject<void>


### PR DESCRIPTION
Allows a consensus provider to be migrated to a new instance of Zkopru.