### PR TITLE
Compile to es6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "moduleResolution": "node",
     "rootDir": ".",


### PR DESCRIPTION
Using the sqlite database is broken because of issues calling static methods on classes in Typescript. This change fixes these issues.

[More info here](https://stackoverflow.com/questions/50203369/class-constructor-cannot-be-invoked-without-new-typescript-with-commonjs/50203532#50203532).

Specifically this issue is occurring [here where an async class method is being invoked](https://github.com/zkopru-network/zkopru/blob/develop/packages/cli/src/apps/coordinator/configurator/config-prompts/load-database.ts#L62). 

If ES5 is needed for downstream projects it may be possible to work around this, though downstream projects could simply use shims.