### PR TITLE
Interactive config creation

### DIFF
--- a/packages/cli/src/apps/coordinator/cli.ts
+++ b/packages/cli/src/apps/coordinator/cli.ts
@@ -3,6 +3,7 @@
 /* eslint-disable no-case-declarations */
 import fs from 'fs-extra'
 import { logStream, logger, makePathAbsolute } from '@zkopru/utils'
+import path from 'path'
 import { argv } from './parser'
 import { Config } from './configurator/configurator'
 import { getCoordinator } from './configurator'
@@ -24,7 +25,9 @@ const main = async () => {
       },
     )
     fs.writeFileSync(outputPath, JSON.stringify(sampleConfig, null, 2))
-    console.log(`Wrote example config to ${shortPath}!`)
+    console.log(
+      `Wrote example config to ${path.relative(process.cwd(), outputPath)}!`,
+    )
     return
   }
   if (argv.config) {

--- a/packages/cli/src/apps/coordinator/cli.ts
+++ b/packages/cli/src/apps/coordinator/cli.ts
@@ -6,8 +6,8 @@ import { logStream, logger, makePathAbsolute } from '@zkopru/utils'
 import { argv } from './parser'
 import { Config } from './configurator/configurator'
 import { getCoordinator } from './configurator'
+import { getExampleConfig } from './example-config'
 import { CoordinatorDashboard } from './app'
-import { DEFAULT, externalIp } from './config'
 
 const main = async () => {
   const writeStream = fs.createWriteStream('./COORDINATOR_LOG')
@@ -16,14 +16,13 @@ const main = async () => {
   if (typeof argv.generateConfig !== 'undefined') {
     // write a sample config file
     const shortPath = argv.generateConfig || './config.json'
-    const outputPath = makePathAbsolute(shortPath)
-    const sampleConfig = {
-      ...DEFAULT,
-      publicUrls: `${await externalIp()}:${DEFAULT.port},127.0.0.1:8888`,
-      sqlite: '/path/to/sqlite/database.sqlite',
-      passwordFile: '/path/to/password_file',
-      keystoreFile: '/path/to/wallet/keystore.json',
-    }
+    const { config: sampleConfig, outputPath } = await getExampleConfig(
+      makePathAbsolute(shortPath),
+      async () => {
+        console.log('Aborting example config creation...')
+        process.exit(1)
+      },
+    )
     fs.writeFileSync(outputPath, JSON.stringify(sampleConfig, null, 2))
     console.log(`Wrote example config to ${shortPath}!`)
     return

--- a/packages/cli/src/apps/coordinator/example-config/index.ts
+++ b/packages/cli/src/apps/coordinator/example-config/index.ts
@@ -2,6 +2,7 @@ import { DEFAULT, externalIp } from '../config'
 import CreateWallet from './prompts/create-wallet'
 import SetPublicUrl from './prompts/set-public-url'
 import SetWebsocket from './prompts/set-websocket'
+import OutputPath from './prompts/output-path'
 import { Config } from '../configurator/configurator'
 import { Menu } from './menu'
 
@@ -21,13 +22,14 @@ export async function getExampleConfig(
     }`,
   } as Config
   const options = {
-    base: exampleConfig,
+    base: undefined,
     onCancel,
   }
   const apps = {
     [Menu.CREATE_WALLET]: new CreateWallet(options),
     [Menu.SET_PUBLIC_URLS]: new SetPublicUrl(options),
     [Menu.SET_WEBSOCKET]: new SetWebsocket(options),
+    [Menu.OUTPUT_PATH]: new OutputPath(options),
   }
   const context = {
     config: exampleConfig,

--- a/packages/cli/src/apps/coordinator/example-config/index.ts
+++ b/packages/cli/src/apps/coordinator/example-config/index.ts
@@ -1,6 +1,7 @@
 import { DEFAULT, externalIp } from '../config'
 import CreateWallet from './prompts/create-wallet'
 import SetPublicUrl from './prompts/set-public-url'
+import SetWebsocket from './prompts/set-websocket'
 import { Config } from '../configurator/configurator'
 import { Menu } from './menu'
 
@@ -26,6 +27,7 @@ export async function getExampleConfig(
   const apps = {
     [Menu.CREATE_WALLET]: new CreateWallet(options),
     [Menu.SET_PUBLIC_URLS]: new SetPublicUrl(options),
+    [Menu.SET_WEBSOCKET]: new SetWebsocket(options),
   }
   let next = Menu.CREATE_WALLET
   while (next !== Menu.COMPLETE) {

--- a/packages/cli/src/apps/coordinator/example-config/index.ts
+++ b/packages/cli/src/apps/coordinator/example-config/index.ts
@@ -29,17 +29,22 @@ export async function getExampleConfig(
     [Menu.SET_PUBLIC_URLS]: new SetPublicUrl(options),
     [Menu.SET_WEBSOCKET]: new SetWebsocket(options),
   }
+  const context = {
+    config: exampleConfig,
+    outputPath,
+  }
   let next = Menu.CREATE_WALLET
   while (next !== Menu.COMPLETE) {
     const app = apps[next]
     if (app) {
-      const { next: newNext, context } = await app.run(exampleConfig)
+      const {
+        next: newNext,
+        context: { config, outputPath: newOutputPath },
+      } = await app.run(context)
       next = newNext
-      Object.assign(exampleConfig, context)
+      Object.assign(context.config, config)
+      context.outputPath = newOutputPath
     } else break
   }
-  return {
-    config: exampleConfig,
-    outputPath,
-  }
+  return context
 }

--- a/packages/cli/src/apps/coordinator/example-config/index.ts
+++ b/packages/cli/src/apps/coordinator/example-config/index.ts
@@ -2,6 +2,7 @@ import { DEFAULT, externalIp } from '../config'
 import CreateWallet from './prompts/create-wallet'
 import SetPublicUrl from './prompts/set-public-url'
 import SetWebsocket from './prompts/set-websocket'
+import SetDB from './prompts/set-db'
 import OutputPath from './prompts/output-path'
 import { Config } from '../configurator/configurator'
 import { Menu } from './menu'
@@ -29,6 +30,7 @@ export async function getExampleConfig(
     [Menu.CREATE_WALLET]: new CreateWallet(options),
     [Menu.SET_PUBLIC_URLS]: new SetPublicUrl(options),
     [Menu.SET_WEBSOCKET]: new SetWebsocket(options),
+    [Menu.SET_DB]: new SetDB(options),
     [Menu.OUTPUT_PATH]: new OutputPath(options),
   }
   const context = {

--- a/packages/cli/src/apps/coordinator/example-config/index.ts
+++ b/packages/cli/src/apps/coordinator/example-config/index.ts
@@ -1,0 +1,43 @@
+import { DEFAULT, externalIp } from '../config'
+import CreateWallet from './prompts/create-wallet'
+import SetPublicUrl from './prompts/set-public-url'
+import { Config } from '../configurator/configurator'
+import { Menu } from './menu'
+
+export async function getExampleConfig(
+  outputPath: string,
+  onError?: () => Promise<void>,
+): Promise<{ config: Config; outputPath: string }> {
+  const onCancel =
+    onError ||
+    (async () => {
+      process.exit(1)
+    })
+  const exampleConfig = {
+    ...DEFAULT,
+    publicUrls: `${await externalIp()}:${DEFAULT.port},127.0.0.1:${
+      DEFAULT.port
+    }`,
+  } as Config
+  const options = {
+    base: exampleConfig,
+    onCancel,
+  }
+  const apps = {
+    [Menu.CREATE_WALLET]: new CreateWallet(options),
+    [Menu.SET_PUBLIC_URLS]: new SetPublicUrl(options),
+  }
+  let next = Menu.CREATE_WALLET
+  while (next !== Menu.COMPLETE) {
+    const app = apps[next]
+    if (app) {
+      const { next: newNext, context } = await app.run(exampleConfig)
+      next = newNext
+      Object.assign(exampleConfig, context)
+    } else break
+  }
+  return {
+    config: exampleConfig,
+    outputPath,
+  }
+}

--- a/packages/cli/src/apps/coordinator/example-config/menu.ts
+++ b/packages/cli/src/apps/coordinator/example-config/menu.ts
@@ -1,0 +1,5 @@
+export enum Menu {
+  CREATE_WALLET,
+  SET_PUBLIC_URLS,
+  COMPLETE,
+}

--- a/packages/cli/src/apps/coordinator/example-config/menu.ts
+++ b/packages/cli/src/apps/coordinator/example-config/menu.ts
@@ -1,6 +1,13 @@
+import { Config } from '../configurator/configurator'
+
 export enum Menu {
   CREATE_WALLET,
   SET_PUBLIC_URLS,
   SET_WEBSOCKET,
   COMPLETE,
+}
+
+export interface ExampleConfigContext {
+  config: Config
+  outputPath: string
 }

--- a/packages/cli/src/apps/coordinator/example-config/menu.ts
+++ b/packages/cli/src/apps/coordinator/example-config/menu.ts
@@ -1,5 +1,6 @@
 export enum Menu {
   CREATE_WALLET,
   SET_PUBLIC_URLS,
+  SET_WEBSOCKET,
   COMPLETE,
 }

--- a/packages/cli/src/apps/coordinator/example-config/menu.ts
+++ b/packages/cli/src/apps/coordinator/example-config/menu.ts
@@ -4,6 +4,7 @@ export enum Menu {
   CREATE_WALLET,
   SET_PUBLIC_URLS,
   SET_WEBSOCKET,
+  OUTPUT_PATH,
   COMPLETE,
 }
 

--- a/packages/cli/src/apps/coordinator/example-config/menu.ts
+++ b/packages/cli/src/apps/coordinator/example-config/menu.ts
@@ -4,6 +4,7 @@ export enum Menu {
   CREATE_WALLET,
   SET_PUBLIC_URLS,
   SET_WEBSOCKET,
+  SET_DB,
   OUTPUT_PATH,
   COMPLETE,
 }

--- a/packages/cli/src/apps/coordinator/example-config/prompts/create-wallet.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/create-wallet.ts
@@ -3,10 +3,9 @@ import Web3 from 'web3'
 import crypto from 'crypto'
 import fs from 'fs'
 import { PromptApp, makePathAbsolute } from '@zkopru/utils'
-import { Config } from '../../configurator/configurator'
 import { Menu, ExampleConfigContext } from '../menu'
 
-export default class Wallet extends PromptApp<ExampleConfigContext, Config> {
+export default class Wallet extends PromptApp<ExampleConfigContext, void> {
   static code = Menu.CREATE_WALLET
 
   async run(

--- a/packages/cli/src/apps/coordinator/example-config/prompts/create-wallet.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/create-wallet.ts
@@ -38,6 +38,7 @@ export default class Wallet extends PromptApp<ExampleConfigContext, void> {
       initial: './password.secret',
     })
     fs.writeFileSync(makePathAbsolute(passwordFile), password)
+    fs.chmodSync(makePathAbsolute(passwordFile), 0o600)
     return {
       context: {
         config: {

--- a/packages/cli/src/apps/coordinator/example-config/prompts/create-wallet.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/create-wallet.ts
@@ -4,12 +4,14 @@ import crypto from 'crypto'
 import fs from 'fs'
 import { PromptApp, makePathAbsolute } from '@zkopru/utils'
 import { Config } from '../../configurator/configurator'
-import { Menu } from '../menu'
+import { Menu, ExampleConfigContext } from '../menu'
 
-export default class Wallet extends PromptApp<Config, Config> {
+export default class Wallet extends PromptApp<ExampleConfigContext, Config> {
   static code = Menu.CREATE_WALLET
 
-  async run(context: Config): Promise<{ context: Config; next: number }> {
+  async run(
+    context: ExampleConfigContext,
+  ): Promise<{ context: ExampleConfigContext; next: number }> {
     console.log(chalk.blue(`Create a wallet?`))
     const { create } = await this.ask({
       type: 'confirm',
@@ -39,9 +41,12 @@ export default class Wallet extends PromptApp<Config, Config> {
     fs.writeFileSync(passwordFile, password)
     return {
       context: {
-        ...context,
-        keystore,
-        passwordFile,
+        config: {
+          ...context.config,
+          keystore,
+          passwordFile,
+        },
+        outputPath: context.outputPath,
       },
       next: Menu.SET_PUBLIC_URLS,
     }

--- a/packages/cli/src/apps/coordinator/example-config/prompts/create-wallet.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/create-wallet.ts
@@ -1,0 +1,49 @@
+import chalk from 'chalk'
+import Web3 from 'web3'
+import crypto from 'crypto'
+import fs from 'fs'
+import { PromptApp, makePathAbsolute } from '@zkopru/utils'
+import { Config } from '../../configurator/configurator'
+import { Menu } from '../menu'
+
+export default class Wallet extends PromptApp<Config, Config> {
+  static code = Menu.CREATE_WALLET
+
+  async run(context: Config): Promise<{ context: Config; next: number }> {
+    console.log(chalk.blue(`Create a wallet?`))
+    const { create } = await this.ask({
+      type: 'confirm',
+      name: 'create',
+      message: `Would you like to create a wallet?`,
+      initial: true,
+    })
+    if (!create) {
+      return { context, next: Menu.SET_PUBLIC_URLS }
+    }
+    const web3 = new Web3()
+    const account = web3.eth.accounts.create()
+    const securePassword = crypto.randomBytes(32).toString('hex')
+    const { password } = await this.ask({
+      type: 'password',
+      name: 'password',
+      message: `Enter a password to encrypt (leave blank to use secure password):`,
+      initial: securePassword,
+    })
+    const keystore = account.encrypt(password)
+    const { passwordFile } = await this.ask({
+      type: 'text',
+      name: 'passwordFile',
+      message: 'Enter a path where the password should be stored',
+      initial: `${makePathAbsolute('./password.secret')}`,
+    })
+    fs.writeFileSync(passwordFile, password)
+    return {
+      context: {
+        ...context,
+        keystore,
+        passwordFile,
+      },
+      next: Menu.SET_PUBLIC_URLS,
+    }
+  }
+}

--- a/packages/cli/src/apps/coordinator/example-config/prompts/create-wallet.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/create-wallet.ts
@@ -27,7 +27,7 @@ export default class Wallet extends PromptApp<ExampleConfigContext, void> {
     const { password } = await this.ask({
       type: 'password',
       name: 'password',
-      message: `Enter a password to encrypt (leave blank to use secure password):`,
+      message: `Enter a password to encrypt (press enter to use secure password):`,
       initial: securePassword,
     })
     const keystore = account.encrypt(password)

--- a/packages/cli/src/apps/coordinator/example-config/prompts/create-wallet.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/create-wallet.ts
@@ -35,9 +35,9 @@ export default class Wallet extends PromptApp<ExampleConfigContext, void> {
       type: 'text',
       name: 'passwordFile',
       message: 'Enter a path where the password should be stored',
-      initial: `${makePathAbsolute('./password.secret')}`,
+      initial: './password.secret',
     })
-    fs.writeFileSync(passwordFile, password)
+    fs.writeFileSync(makePathAbsolute(passwordFile), password)
     return {
       context: {
         config: {

--- a/packages/cli/src/apps/coordinator/example-config/prompts/output-path.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/output-path.ts
@@ -1,0 +1,24 @@
+import { PromptApp, makePathAbsolute } from '@zkopru/utils'
+import { Menu, ExampleConfigContext } from '../menu'
+
+export default class OutputPath extends PromptApp<ExampleConfigContext, void> {
+  static code = Menu.OUTPUT_PATH
+
+  async run(
+    context: ExampleConfigContext,
+  ): Promise<{ context: ExampleConfigContext; next: number }> {
+    const { outputPath } = await this.ask({
+      type: 'text',
+      name: 'outputPath',
+      message: `Where should this config be written?`,
+      initial: context.outputPath,
+    })
+    return {
+      context: {
+        ...context,
+        outputPath: makePathAbsolute(outputPath),
+      },
+      next: Menu.COMPLETE,
+    }
+  }
+}

--- a/packages/cli/src/apps/coordinator/example-config/prompts/output-path.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/output-path.ts
@@ -1,4 +1,5 @@
 import { PromptApp, makePathAbsolute } from '@zkopru/utils'
+import path from 'path'
 import { Menu, ExampleConfigContext } from '../menu'
 
 export default class OutputPath extends PromptApp<ExampleConfigContext, void> {
@@ -11,7 +12,10 @@ export default class OutputPath extends PromptApp<ExampleConfigContext, void> {
       type: 'text',
       name: 'outputPath',
       message: `Where should this config be written?`,
-      initial: context.outputPath,
+      initial: path.relative(
+        process.cwd(),
+        makePathAbsolute(context.outputPath),
+      ),
     })
     return {
       context: {

--- a/packages/cli/src/apps/coordinator/example-config/prompts/set-db.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/set-db.ts
@@ -1,0 +1,58 @@
+import { PromptApp, makePathAbsolute } from '@zkopru/utils'
+import { Menu, ExampleConfigContext } from '../menu'
+
+export default class SetDB extends PromptApp<ExampleConfigContext, void> {
+  static code = Menu.SET_DB
+
+  async run(
+    context: ExampleConfigContext,
+  ): Promise<{ context: ExampleConfigContext; next: number }> {
+    const enum DBType {
+      SQLITE,
+      POSTGRES,
+    }
+    const { dbType } = await this.ask({
+      type: 'select',
+      name: 'dbType',
+      message: `Which database would you like to use?`,
+      initial: DBType.SQLITE,
+      choices: [
+        {
+          title: 'SQLite',
+          value: DBType.SQLITE,
+        },
+        {
+          title: 'PostgreSQL',
+          value: DBType.POSTGRES,
+        },
+      ],
+    })
+    const db = {}
+    if (dbType === DBType.SQLITE) {
+      const { sqlite } = await this.ask({
+        type: 'text',
+        name: 'sqlite',
+        message: 'Where should the database be stored?',
+        initial: './database.sqlite',
+      })
+      Object.assign(db, { sqlite: makePathAbsolute(sqlite) })
+    } else {
+      const { postgres } = await this.ask({
+        type: 'text',
+        name: 'postgres',
+        message: 'Enter your postgre url',
+      })
+      Object.assign(db, { postgres })
+    }
+    return {
+      context: {
+        config: {
+          ...context.config,
+          ...db,
+        },
+        outputPath: context.outputPath,
+      },
+      next: Menu.OUTPUT_PATH,
+    }
+  }
+}

--- a/packages/cli/src/apps/coordinator/example-config/prompts/set-db.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/set-db.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk'
 import { PromptApp, makePathAbsolute } from '@zkopru/utils'
 import { Menu, ExampleConfigContext } from '../menu'
 
@@ -7,6 +8,7 @@ export default class SetDB extends PromptApp<ExampleConfigContext, void> {
   async run(
     context: ExampleConfigContext,
   ): Promise<{ context: ExampleConfigContext; next: number }> {
+    console.log(chalk.blue(`Database`))
     const enum DBType {
       SQLITE,
       POSTGRES,
@@ -40,7 +42,7 @@ export default class SetDB extends PromptApp<ExampleConfigContext, void> {
       const { postgres } = await this.ask({
         type: 'text',
         name: 'postgres',
-        message: 'Enter your postgre url',
+        message: 'Enter your postgres url',
       })
       Object.assign(db, { postgres })
     }

--- a/packages/cli/src/apps/coordinator/example-config/prompts/set-public-url.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/set-public-url.ts
@@ -1,15 +1,19 @@
 import chalk from 'chalk'
 import { PromptApp, validatePublicUrls } from '@zkopru/utils'
 import { Config } from '../../configurator/configurator'
-import { Menu } from '../menu'
+import { Menu, ExampleConfigContext } from '../menu'
 
-export default class Wallet extends PromptApp<Config, Config> {
+export default class Wallet extends PromptApp<ExampleConfigContext, Config> {
   static code = Menu.SET_PUBLIC_URLS
 
-  async run(context: Config): Promise<{ context: Config; next: number }> {
+  async run(
+    context: ExampleConfigContext,
+  ): Promise<{ context: ExampleConfigContext; next: number }> {
     console.log(chalk.blue('Public URLs'))
     console.log(
-      `Your detected public urls are: ${chalk.bold(context.publicUrls || '')}`,
+      `Your detected public urls are: ${chalk.bold(
+        context.config.publicUrls || '',
+      )}`,
     )
     const { update } = await this.ask({
       type: 'confirm',
@@ -23,7 +27,7 @@ export default class Wallet extends PromptApp<Config, Config> {
       const { urls } = await this.ask({
         type: 'text',
         name: 'urls',
-        initial: context.publicUrls,
+        initial: context.config.publicUrls,
         message: 'Enter new host:port entries separated by commas',
       })
       try {
@@ -33,6 +37,15 @@ export default class Wallet extends PromptApp<Config, Config> {
         console.log(chalk.red(err.message))
       }
     } while (!publicUrls)
-    return { context: { ...context, publicUrls }, next: Menu.SET_WEBSOCKET }
+    return {
+      context: {
+        config: {
+          ...context.config,
+          publicUrls,
+        },
+        outputPath: context.outputPath,
+      },
+      next: Menu.SET_WEBSOCKET,
+    }
   }
 }

--- a/packages/cli/src/apps/coordinator/example-config/prompts/set-public-url.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/set-public-url.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk'
-import { PromptApp } from '@zkopru/utils'
+import { PromptApp, validatePublicUrls } from '@zkopru/utils'
 import { Config } from '../../configurator/configurator'
 import { Menu } from '../menu'
 
@@ -18,13 +18,21 @@ export default class Wallet extends PromptApp<Config, Config> {
       initial: false,
     })
     if (!update) return { context, next: Menu.COMPLETE }
-    const { urls } = await this.ask({
-      type: 'text',
-      name: 'urls',
-      initial: context.publicUrls,
-      message: 'Enter new host:port entries separated by commas',
-    })
-    // TODO: validate entry
-    return { context: { ...context, publicUrls: urls }, next: Menu.COMPLETE }
+    let publicUrls: string|undefined
+    do {
+      const { urls } = await this.ask({
+        type: 'text',
+        name: 'urls',
+        initial: context.publicUrls,
+        message: 'Enter new host:port entries separated by commas',
+      })
+      try {
+        validatePublicUrls(urls)
+        publicUrls = urls
+      } catch (err) {
+        console.log(chalk.red(err.message))
+      }
+    } while (!publicUrls)
+    return { context: { ...context, publicUrls }, next: Menu.COMPLETE }
   }
 }

--- a/packages/cli/src/apps/coordinator/example-config/prompts/set-public-url.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/set-public-url.ts
@@ -1,0 +1,30 @@
+import chalk from 'chalk'
+import { PromptApp } from '@zkopru/utils'
+import { Config } from '../../configurator/configurator'
+import { Menu } from '../menu'
+
+export default class Wallet extends PromptApp<Config, Config> {
+  static code = Menu.SET_PUBLIC_URLS
+
+  async run(context: Config): Promise<{ context: Config; next: number }> {
+    console.log(chalk.blue('Public URLs'))
+    console.log(
+      `Your detected public urls are: ${chalk.bold(context.publicUrls || '')}`,
+    )
+    const { update } = await this.ask({
+      type: 'confirm',
+      name: 'update',
+      message: `Would you like to update your public urls?`,
+      initial: false,
+    })
+    if (!update) return { context, next: Menu.COMPLETE }
+    const { urls } = await this.ask({
+      type: 'text',
+      name: 'urls',
+      initial: context.publicUrls,
+      message: 'Enter new host:port entries separated by commas',
+    })
+    // TODO: validate entry
+    return { context: { ...context, publicUrls: urls }, next: Menu.COMPLETE }
+  }
+}

--- a/packages/cli/src/apps/coordinator/example-config/prompts/set-public-url.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/set-public-url.ts
@@ -17,7 +17,7 @@ export default class Wallet extends PromptApp<Config, Config> {
       message: `Would you like to update your public urls?`,
       initial: false,
     })
-    if (!update) return { context, next: Menu.COMPLETE }
+    if (!update) return { context, next: Menu.SET_WEBSOCKET }
     let publicUrls: string|undefined
     do {
       const { urls } = await this.ask({
@@ -33,6 +33,6 @@ export default class Wallet extends PromptApp<Config, Config> {
         console.log(chalk.red(err.message))
       }
     } while (!publicUrls)
-    return { context: { ...context, publicUrls }, next: Menu.COMPLETE }
+    return { context: { ...context, publicUrls }, next: Menu.SET_WEBSOCKET }
   }
 }

--- a/packages/cli/src/apps/coordinator/example-config/prompts/set-public-url.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/set-public-url.ts
@@ -1,9 +1,8 @@
 import chalk from 'chalk'
 import { PromptApp, validatePublicUrls } from '@zkopru/utils'
-import { Config } from '../../configurator/configurator'
 import { Menu, ExampleConfigContext } from '../menu'
 
-export default class Wallet extends PromptApp<ExampleConfigContext, Config> {
+export default class Wallet extends PromptApp<ExampleConfigContext, void> {
   static code = Menu.SET_PUBLIC_URLS
 
   async run(

--- a/packages/cli/src/apps/coordinator/example-config/prompts/set-public-url.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/set-public-url.ts
@@ -18,7 +18,7 @@ export default class Wallet extends PromptApp<Config, Config> {
       initial: false,
     })
     if (!update) return { context, next: Menu.SET_WEBSOCKET }
-    let publicUrls: string|undefined
+    let publicUrls: string | undefined
     do {
       const { urls } = await this.ask({
         type: 'text',

--- a/packages/cli/src/apps/coordinator/example-config/prompts/set-websocket.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/set-websocket.ts
@@ -63,7 +63,7 @@ export default class Wallet extends PromptApp<ExampleConfigContext, void> {
         },
         outputPath: context.outputPath,
       },
-      next: Menu.OUTPUT_PATH,
+      next: Menu.SET_DB,
     }
   }
 }

--- a/packages/cli/src/apps/coordinator/example-config/prompts/set-websocket.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/set-websocket.ts
@@ -1,0 +1,57 @@
+import chalk from 'chalk'
+import { PromptApp } from '@zkopru/utils'
+import Web3 from 'web3'
+import { Config } from '../../configurator/configurator'
+import { Menu } from '../menu'
+
+const addressesByNetworkId = {
+  '1': undefined,
+  '5': '0xF4A46BEA80d0D21a11306DDE6cb0fFA91fF95ADd',
+}
+
+export default class Wallet extends PromptApp<Config, Config> {
+  static code = Menu.SET_WEBSOCKET
+
+  async run(context: Config): Promise<{ context: Config; next: number }> {
+    console.log(chalk.blue('Geth Websocket'))
+    let websocket = ''
+    let address = context.address
+    do {
+      const { websocketUrl } = await this.ask({
+        type: 'text',
+        name: 'websocketUrl',
+        message: 'Enter an Ethereum websocket url',
+      })
+      if (
+        websocketUrl.indexOf('ws') !== 0 &&
+        websocketUrl.indexOf('wss') !== 0
+      ) {
+        console.log(chalk.red('Websocket url must start with ws:// or wss://'))
+        continue
+      }
+      try {
+        const web3 = new Web3(websocketUrl)
+        const chainId = await web3.eth.getChainId()
+        address = addressesByNetworkId[chainId.toString(10)]
+        if (address) {
+          websocket = websocketUrl
+          break
+        }
+        const { confirm } = await this.ask({
+          type: 'confirm',
+          name: 'confirm',
+          message: `Zkopru is not deployed on this network (${chainId}), continue?`,
+        })
+        if (confirm) {
+          websocket = websocketUrl
+          address = ''
+          break
+        }
+      } catch (err) {
+        console.log(chalk.red('Error connecting to Ethereum node'))
+        console.log(err)
+      }
+    } while (!websocket)
+    return { context: { ...context, address, websocket }, next: Menu.COMPLETE }
+  }
+}

--- a/packages/cli/src/apps/coordinator/example-config/prompts/set-websocket.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/set-websocket.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk'
 import { PromptApp } from '@zkopru/utils'
 import Web3 from 'web3'
-import { Config } from '../../configurator/configurator'
 import { Menu, ExampleConfigContext } from '../menu'
 
 const addressesByNetworkId = {
@@ -9,7 +8,7 @@ const addressesByNetworkId = {
   '5': '0xF4A46BEA80d0D21a11306DDE6cb0fFA91fF95ADd',
 }
 
-export default class Wallet extends PromptApp<ExampleConfigContext, Config> {
+export default class Wallet extends PromptApp<ExampleConfigContext, void> {
   static code = Menu.SET_WEBSOCKET
 
   async run(
@@ -64,7 +63,7 @@ export default class Wallet extends PromptApp<ExampleConfigContext, Config> {
         },
         outputPath: context.outputPath,
       },
-      next: Menu.COMPLETE,
+      next: Menu.OUTPUT_PATH,
     }
   }
 }

--- a/packages/cli/src/apps/coordinator/example-config/prompts/set-websocket.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/set-websocket.ts
@@ -15,7 +15,7 @@ export default class Wallet extends PromptApp<Config, Config> {
   async run(context: Config): Promise<{ context: Config; next: number }> {
     console.log(chalk.blue('Geth Websocket'))
     let websocket = ''
-    let address = context.address
+    let { address } = context
     do {
       const { websocketUrl } = await this.ask({
         type: 'text',
@@ -27,6 +27,7 @@ export default class Wallet extends PromptApp<Config, Config> {
         websocketUrl.indexOf('wss') !== 0
       ) {
         console.log(chalk.red('Websocket url must start with ws:// or wss://'))
+        // eslint-disable-next-line no-continue
         continue
       }
       try {

--- a/packages/cli/src/apps/coordinator/example-config/prompts/set-websocket.ts
+++ b/packages/cli/src/apps/coordinator/example-config/prompts/set-websocket.ts
@@ -2,20 +2,22 @@ import chalk from 'chalk'
 import { PromptApp } from '@zkopru/utils'
 import Web3 from 'web3'
 import { Config } from '../../configurator/configurator'
-import { Menu } from '../menu'
+import { Menu, ExampleConfigContext } from '../menu'
 
 const addressesByNetworkId = {
   '1': undefined,
   '5': '0xF4A46BEA80d0D21a11306DDE6cb0fFA91fF95ADd',
 }
 
-export default class Wallet extends PromptApp<Config, Config> {
+export default class Wallet extends PromptApp<ExampleConfigContext, Config> {
   static code = Menu.SET_WEBSOCKET
 
-  async run(context: Config): Promise<{ context: Config; next: number }> {
+  async run(
+    context: ExampleConfigContext,
+  ): Promise<{ context: ExampleConfigContext; next: number }> {
     console.log(chalk.blue('Geth Websocket'))
     let websocket = ''
-    let { address } = context
+    let { address } = context.config
     do {
       const { websocketUrl } = await this.ask({
         type: 'text',
@@ -53,6 +55,16 @@ export default class Wallet extends PromptApp<Config, Config> {
         console.log(err)
       }
     } while (!websocket)
-    return { context: { ...context, address, websocket }, next: Menu.COMPLETE }
+    return {
+      context: {
+        config: {
+          ...context.config,
+          address,
+          websocket,
+        },
+        outputPath: context.outputPath,
+      },
+      next: Menu.COMPLETE,
+    }
   }
 }

--- a/packages/coordinator/src/auction-monitor.ts
+++ b/packages/coordinator/src/auction-monitor.ts
@@ -4,14 +4,10 @@ import { FullNode } from '@zkopru/core'
 import BN from 'bn.js'
 import { Account } from 'web3-core'
 import { BlockHeader } from 'web3-eth'
-import { logger } from '@zkopru/utils'
+import { logger, validatePublicUrls } from '@zkopru/utils'
 import AsyncLock from 'async-lock'
 import { EventEmitter } from 'events'
 import axios from 'axios'
-
-const HostRegex = /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$)/
-const IP4Regex = /^((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])(\.(?!$)|$)){4}$/
-const PortRegex = /^[0-9]+$/
 
 export interface AuctionMonitorConfig {
   port: number
@@ -135,18 +131,8 @@ export class AuctionMonitor {
       .coordinatorUrls(this.account.address)
       .call()
     if (!myUrl || myUrl !== newUrl) {
-      for (const url of newUrl.split(',')) {
-        const [host, port] = url.split(':')
-        if (!host || !port) {
-          throw new Error('Missing host or port in public url')
-        }
-        if (!HostRegex.test(host) && !IP4Regex.test(host)) {
-          throw new Error(`Invalid public url host or ip supplied: ${url}`)
-        }
-        if (!PortRegex.test(port)) {
-          throw new Error(`Invalid public url port supplied: ${url}`)
-        }
-      }
+      // This will throw if invalid
+      validatePublicUrls(newUrl)
       logger.info(`Setting public urls: ${newUrl}`)
       await this.updateUrl(newUrl)
     }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -299,7 +299,8 @@ const HostRegex = /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,
 const IP4Regex = /^((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])(\.(?!$)|$)){4}$/
 const PortRegex = /^[0-9]+$/
 export function validatePublicUrls(publicUrls: string) {
-  if (!publicUrls) throw new Error('Public urls cannot be empty for a coordinator')
+  if (!publicUrls)
+    throw new Error('Public urls cannot be empty for a coordinator')
   for (const url of publicUrls.split(',')) {
     const [host, port] = url.split(':')
     if (!host || !port) {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -294,3 +294,22 @@ export function makePathAbsolute(filepath: string) {
   if (path.isAbsolute(filepath)) return filepath
   return path.join(process.cwd(), filepath)
 }
+
+const HostRegex = /(?=^.{4,253}$)(^((?!-)[a-zA-Z0-9-]{1,63}(?<!-)\.)+[a-zA-Z]{2,63}$)/
+const IP4Regex = /^((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])(\.(?!$)|$)){4}$/
+const PortRegex = /^[0-9]+$/
+export function validatePublicUrls(publicUrls: string) {
+  if (!publicUrls) throw new Error('Public urls cannot be empty for a coordinator')
+  for (const url of publicUrls.split(',')) {
+    const [host, port] = url.split(':')
+    if (!host || !port) {
+      throw new Error(`Missing host or port in public url: ${url}`)
+    }
+    if (!HostRegex.test(host) && !IP4Regex.test(host)) {
+      throw new Error(`Invalid public url host or ip supplied: ${url}`)
+    }
+    if (!PortRegex.test(port)) {
+      throw new Error(`Invalid public url port supplied: ${url}`)
+    }
+  }
+}


### PR DESCRIPTION
This PR makes the `--generateConfig` flag interactive. Ideally a coordinator operator would simply do the following:

```sh
$ zkopru --generateConfig
$ zkopru --config ./config.json --daemon
```

![image](https://user-images.githubusercontent.com/631020/105255745-d0473580-5b49-11eb-8e94-8a31eb04b7b5.png)

Output of the above

`custom-config.json`:
```json
{
  "address": "0xF4A46BEA80d0D21a11306DDE6cb0fFA91fF95ADd",
  "bootstrap": true,
  "websocket": "ws://192.168.1.199:9546",
  "maxBytes": 131072,
  "priceMultiplier": 48,
  "port": 8888,
  "maxBid": 20000,
  "daemon": false,
  "publicUrls": "my-url.domain.com:8888,127.0.0.1:8888",
  "keystore": {
    "version": 3,
    "id": "f28c77b3-93de-4573-80d6-6efb51bf14a0",
    "address": "a8a25c573060ce39ade23af46893686c46f2e7cc",
    "crypto": {
      "ciphertext": "58136576004760d5247f025d33ba5b76d6667972acbc8997351e305c24205079",
      "cipherparams": {
        "iv": "d7050691001729962f6240d4501d2dcb"
      },
      "cipher": "aes-128-ctr",
      "kdf": "scrypt",
      "kdfparams": {
        "dklen": 32,
        "salt": "389654469fd28bb10065e6238221f1af6e7b6df55a2a29623e544416bbed2c8c",
        "n": 8192,
        "r": 8,
        "p": 1
      },
      "mac": "579988a8b2dc2d7197a49762f188c51bb75750c1757f3c7dac198ffc0279e4c4"
    }
  },
  "passwordFile": "./password.secret",
  "sqlite": "/home/chance/work/zkopru/packages/cli/database.sqlite"
}
```

`password.secret`:
```
743365d8dd245f03e9c366e8836c893b013b09cb949c62be3b3e78567a083129
```

Closes #144 