### PR TITLE
Ensure poseidon contracts exist for linking

### DIFF
--- a/packages/contracts/migrations/16_zk_optimistic_rollup.js
+++ b/packages/contracts/migrations/16_zk_optimistic_rollup.js
@@ -3,6 +3,7 @@ const Zkopru = artifacts.require("Zkopru");
 
 module.exports = function migration(deployer, _, accounts) {
   deployer.then(async () => {
+    await deployer.deploy(Poseidon2, { overwrite: false });
     await deployer.link(Poseidon2, Zkopru);
     await deployer.deploy(Zkopru, accounts[0]);
   });

--- a/packages/contracts/migrations/4_ui.js
+++ b/packages/contracts/migrations/4_ui.js
@@ -4,6 +4,8 @@ const UserInteractable = artifacts.require("UserInteractable");
 
 module.exports = function migration(deployer) {
   return deployer.then(async () => {
+    await deployer.deploy(Poseidon3, { overwrite: false });
+    await deployer.deploy(Poseidon4, { overwrite: false });
     await deployer.link(Poseidon3, UserInteractable);
     await deployer.link(Poseidon4, UserInteractable);
     await deployer.deploy(UserInteractable);

--- a/packages/contracts/migrations/6_utxo_tree_validator.js
+++ b/packages/contracts/migrations/6_utxo_tree_validator.js
@@ -3,6 +3,7 @@ const UtxoTreeValidator = artifacts.require("UtxoTreeValidator");
 
 module.exports = function migration(deployer) {
   deployer.then(async () => {
+    await deployer.deploy(Poseidon2, { overwrite: false });
     await deployer.link(Poseidon2, UtxoTreeValidator);
     await deployer.deploy(UtxoTreeValidator);
   });


### PR DESCRIPTION
Closes #182 

Working on deploying a new set of contracts to the Goerli testnet. Semi-blocked by the berlin hardfork and [this issue](https://github.com/trufflesuite/truffle/issues/3935), currently updating my local node to use `--rpc.allow-unprotected-txs` for deployment.