### PR TITLE
Fix nonce race condition

### DIFF
--- a/packages/coordinator/tests/unit/coordinator.test.ts
+++ b/packages/coordinator/tests/unit/coordinator.test.ts
@@ -111,7 +111,7 @@ describe('coordinator test to run testnet', () => {
       db: mockup,
       accounts,
     })
-  }, 60000)
+  }, 90000)
   afterAll(async () => {
     await coordinator.stop()
     wsProvider.disconnect(0, 'close connection')

--- a/packages/integration-test/tests/index.test.ts
+++ b/packages/integration-test/tests/index.test.ts
@@ -155,7 +155,7 @@ describe('testnet', () => {
       it(
         'should process the new submitted block',
         waitCoordinatorToProcessTheNewBlock(ctx),
-        30000,
+        40000,
       )
     })
     describe('new block should update trees', () => {

--- a/packages/integration-test/tests/index.test.ts
+++ b/packages/integration-test/tests/index.test.ts
@@ -155,7 +155,7 @@ describe('testnet', () => {
       it(
         'should process the new submitted block',
         waitCoordinatorToProcessTheNewBlock(ctx),
-        40000,
+        60000,
       )
     })
     describe('new block should update trees', () => {


### PR DESCRIPTION
Uses the default web3 nonce handling instead of counting pending transactions ourselves.

Closes #189 