### PR TITLE
Indexed db performance

### DIFF
--- a/packages/core/src/node/block-processor.ts
+++ b/packages/core/src/node/block-processor.ts
@@ -111,6 +111,7 @@ export class BlockProcessor extends EventEmitter {
             include: { block: true },
           })
           const latest = latestProcessed.pop()
+          await this.calcCanonicalBlockHeights(latest?.proposalNum)
           this.emit('processed', { proposalNum: latest?.proposalNum || 0 })
           // this.synchronizer.setLatestProcessed(latest?.proposalNum || 0)
           break

--- a/packages/database/src/connectors/indexed-db.ts
+++ b/packages/database/src/connectors/indexed-db.ts
@@ -386,11 +386,12 @@ export class IndexedDBConnector extends DB {
       const obj = cursor.value
       const topWhere = { ...where, OR: undefined }
       const or = where.OR || []
-      if (or.length === 0 && matchDoc(topWhere, obj)) {
+      const matched = matchDoc(topWhere, obj)
+      if (or.length === 0 && matched) {
         found.push(obj)
       }
       for (const _where of or) {
-        if (matchDoc(_where, obj) && matchDoc(topWhere, obj)) {
+        if (matchDoc(_where, obj) && matched) {
           found.push(obj)
           break
         }

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -320,6 +320,11 @@ export default [
   {
     name: 'TreeNode',
     primaryKey: ['treeId', 'nodeIndex'],
+    indexes: [
+      {
+        keys: ['nodeIndex', 'treeId'],
+      },
+    ],
     rows: [
       ['treeId', 'String'],
       ['nodeIndex', 'String'],


### PR DESCRIPTION
Accelerates simple queries in IndexedDB when possible. Reduces block synchronization time for current test chain in browser from `23 minutes` to `1 minute 20 seconds`. This is comparable to sqlite sync performance in cli.

Adds compound index syntax to schema definition. Index support in IndexedDB version bumps.