### PR TITLE
Atomic sync

### DIFF
--- a/packages/contracts/test-cases/test/libraries/utxo-tree.soltest.js
+++ b/packages/contracts/test-cases/test/libraries/utxo-tree.soltest.js
@@ -5,7 +5,7 @@
 const chai = require("chai");
 const { UtxoTree, poseidonHasher } = require("~tree");
 const { append, appendAsSubTrees } = require("~tree/utils/merkle-tree-sol");
-const sample = require("~tree/sample");
+const sample = require("~tree/sample").default;
 const { Fp } = require("~babyjubjub");
 
 const { expect } = chai;
@@ -35,7 +35,7 @@ const appendSubTree = async (tree, subtreeSize, leaves) => {
       .add(totalItemLen)
       .lte(tree.maxSize())
   ) {
-    const result = await tree.dryAppend(...fixedSizeUtxos);
+    const result = await tree.dryAppend(fixedSizeUtxos);
     return result;
   }
   throw Error("utxo tree flushes.");
@@ -65,7 +65,7 @@ contract("Utxo tree update tests", async accounts => {
       // const prevIndex = tsTree.latestLeafIndex()
       const leaves = [Fp.from("1"), Fp.from("2")];
       const prevTree = tsTree.getStartingLeafProof();
-      const utxoTreeResult = await tsTree.dryAppend(...leaves.map(toLeaf));
+      const utxoTreeResult = await tsTree.dryAppend(leaves.map(toLeaf));
       // console.log(utxoTreeResult)
       // console.log(siblings)
       const solidityAppendResult = await solTree.append(

--- a/packages/core/src/node/block-processor.ts
+++ b/packages/core/src/node/block-processor.ts
@@ -116,9 +116,6 @@ export class BlockProcessor extends EventEmitter {
           })
           const latest = latestProcessed.pop()
           await this.calcCanonicalBlockHeights(latest?.proposalNum)
-          // once we're out of unprocessed blocks update utxos and withdrawals
-          // await this.db.transaction(db => {
-          // })
           this.emit('processed', { proposalNum: latest?.proposalNum || 0 })
           // this.synchronizer.setLatestProcessed(latest?.proposalNum || 0)
           break

--- a/packages/core/src/node/block-processor.ts
+++ b/packages/core/src/node/block-processor.ts
@@ -6,7 +6,6 @@ import {
   Proposal,
   MassDeposit as MassDepositSql,
   TransactionDB,
-  clearTreeCache,
 } from '@zkopru/database'
 import { logger, Worker } from '@zkopru/utils'
 import assert from 'assert'
@@ -228,7 +227,6 @@ export class BlockProcessor extends EventEmitter {
         },
       })
     })
-    clearTreeCache()
     // TODO remove proposal data if it completes verification or if the block is finalized
     return proposal.proposalNum
   }

--- a/packages/core/src/node/block-processor.ts
+++ b/packages/core/src/node/block-processor.ts
@@ -6,6 +6,7 @@ import {
   Proposal,
   MassDeposit as MassDepositSql,
   TransactionDB,
+  clearTreeCache,
 } from '@zkopru/database'
 import { logger, Worker } from '@zkopru/utils'
 import assert from 'assert'
@@ -227,6 +228,7 @@ export class BlockProcessor extends EventEmitter {
         },
       })
     })
+    clearTreeCache()
     // TODO remove proposal data if it completes verification or if the block is finalized
     return proposal.proposalNum
   }
@@ -396,7 +398,7 @@ export class BlockProcessor extends EventEmitter {
 
     db.update('Utxo', {
       where: {
-        hash: patch.treePatch?.utxos.map(utxo =>
+        hash: (patch.treePatch?.utxos || []).map(utxo =>
           utxo.hash.toUint256().toString(),
         ),
       },
@@ -405,7 +407,7 @@ export class BlockProcessor extends EventEmitter {
     logger.trace('mark utxos as unspent')
     db.update('Withdrawal', {
       where: {
-        hash: patch.treePatch?.withdrawals.map(withdrawal => {
+        hash: (patch.treePatch?.withdrawals || []).map(withdrawal => {
           assert(withdrawal.noteHash)
           return withdrawal.noteHash.toString()
         }),

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -153,7 +153,7 @@ Batch database operations to be executed at once. If any operation in the transa
 
 `operation`: A function performing database operations.
 
-`TransactionDB`: A pseudo object with the following functions: `create`, `update`, `upsert`, `delete`. Each function behaves the same as the normal version BUT the functions are not asynchronous, they return immediately.
+`TransactionDB`: A pseudo object with the following functions: `create`, `update`, `upsert`, `delete`, `onCommitted`. Each function behaves the same as the normal version BUT the functions are not asynchronous, they return immediately but data is not persisted until the transaction is committed. `onCommitted` allows a function to be registered as a callback when the transaction is successfully completed. `onCommitted` callbacks are not executed if the transaction errors.
 
 Once the `operation` function finishes executing the transaction will be applied.
 

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -153,7 +153,7 @@ Batch database operations to be executed at once. If any operation in the transa
 
 `operation`: A function performing database operations.
 
-`TransactionDB`: A pseudo object with the following functions: `create`, `update`, `upsert`, `delete`, `onCommitted`. Each function behaves the same as the normal version BUT the functions are not asynchronous, they return immediately but data is not persisted until the transaction is committed. `onCommitted` allows a function to be registered as a callback when the transaction is successfully completed. `onCommitted` callbacks are not executed if the transaction errors.
+`TransactionDB`: A pseudo object with the following functions: `create`, `update`, `upsert`, `delete`, `onCommit`, `onError`, `onComplete`. Each function behaves the same as the normal version BUT the functions are not asynchronous, they return immediately but data is not persisted until the transaction is committed. `onCommit` allows a function to be registered as a callback when the transaction is successfully committed. `onError` registers a callback that is executed if the transaction errors. `onComplete` is executed regardless of success or error.
 
 Once the `operation` function finishes executing the transaction will be applied.
 

--- a/packages/database/src/connectors/postgres.ts
+++ b/packages/database/src/connectors/postgres.ts
@@ -252,6 +252,7 @@ export class PostgresConnector extends DB {
   private async _transaction(operation: (db: TransactionDB) => void) {
     if (typeof operation !== 'function') throw new Error('Invalid operation')
     const sqlOperations = [] as string[]
+    const onCommittedCallbacks = [] as Function[]
     const transactionDB = {
       create: (collection: string, _doc: any) => {
         const table = this.schema[collection]
@@ -279,6 +280,11 @@ export class PostgresConnector extends DB {
         const sql = upsertSql(table, options)
         sqlOperations.push(sql)
       },
+      onCommitted: (cb: Function) => {
+        if (typeof cb !== 'function')
+          throw new Error('Non-function onCommitted callback supplied')
+        onCommittedCallbacks.push(cb)
+      },
     }
     await Promise.resolve(operation(transactionDB))
     // now apply the transaction
@@ -287,6 +293,9 @@ export class PostgresConnector extends DB {
     COMMIT;`
     try {
       await this.db.query(transactionSql)
+      for (const cb of onCommittedCallbacks) {
+        cb()
+      }
     } catch (err) {
       await this.db.query('ROLLBACK;')
       throw err

--- a/packages/database/src/connectors/postgres.ts
+++ b/packages/database/src/connectors/postgres.ts
@@ -59,7 +59,9 @@ export class PostgresConnector extends DB {
   }
 
   async create(collection: string, _doc: any) {
-    return this.lock.acquire('db', async () => this._create(collection, _doc))
+    return this.lock.acquire('write', async () =>
+      this._create(collection, _doc),
+    )
   }
 
   private async _create(collection: string, _doc: any) {
@@ -79,7 +81,7 @@ export class PostgresConnector extends DB {
   }
 
   async findOne(collection: string, options: FindOneOptions) {
-    return this.lock.acquire('db', async () =>
+    return this.lock.acquire('read', async () =>
       this._findOne(collection, options),
     )
   }
@@ -146,7 +148,7 @@ export class PostgresConnector extends DB {
   }
 
   async findMany(collection: string, options: FindManyOptions) {
-    return this.lock.acquire('db', async () =>
+    return this.lock.acquire('read', async () =>
       this._findMany(collection, options),
     )
   }
@@ -182,7 +184,7 @@ export class PostgresConnector extends DB {
   }
 
   async count(collection: string, where: WhereClause) {
-    return this.lock.acquire('db', async () => this._count(collection, where))
+    return this.lock.acquire('read', async () => this._count(collection, where))
   }
 
   private async _count(collection: string, where: WhereClause) {
@@ -194,7 +196,7 @@ export class PostgresConnector extends DB {
   }
 
   async update(collection: string, options: UpdateOptions) {
-    return this.lock.acquire('db', async () =>
+    return this.lock.acquire('write', async () =>
       this._update(collection, options),
     )
   }
@@ -210,7 +212,7 @@ export class PostgresConnector extends DB {
   }
 
   async upsert(collection: string, options: UpsertOptions) {
-    return this.lock.acquire('db', async () =>
+    return this.lock.acquire('write', async () =>
       this._upsert(collection, options),
     )
   }
@@ -224,7 +226,7 @@ export class PostgresConnector extends DB {
   }
 
   async delete(collection: string, options: DeleteManyOptions) {
-    return this.lock.acquire('db', async () =>
+    return this.lock.acquire('write', async () =>
       this._deleteMany(collection, options),
     )
   }
@@ -244,7 +246,7 @@ export class PostgresConnector extends DB {
   }
 
   async transaction(operation: (db: TransactionDB) => void) {
-    return this.lock.acquire('db', async () => this._transaction(operation))
+    return this.lock.acquire('write', async () => this._transaction(operation))
   }
 
   private async _transaction(operation: (db: TransactionDB) => void) {

--- a/packages/database/src/connectors/postgres.ts
+++ b/packages/database/src/connectors/postgres.ts
@@ -252,7 +252,9 @@ export class PostgresConnector extends DB {
   private async _transaction(operation: (db: TransactionDB) => void) {
     if (typeof operation !== 'function') throw new Error('Invalid operation')
     const sqlOperations = [] as string[]
-    const onCommittedCallbacks = [] as Function[]
+    const onCommitCallbacks = [] as Function[]
+    const onErrorCallbacks = [] as Function[]
+    const onCompleteCallbacks = [] as Function[]
     const transactionDB = {
       create: (collection: string, _doc: any) => {
         const table = this.schema[collection]
@@ -280,10 +282,20 @@ export class PostgresConnector extends DB {
         const sql = upsertSql(table, options)
         sqlOperations.push(sql)
       },
-      onCommitted: (cb: Function) => {
+      onCommit: (cb: Function) => {
         if (typeof cb !== 'function')
-          throw new Error('Non-function onCommitted callback supplied')
-        onCommittedCallbacks.push(cb)
+          throw new Error('Non-function onCommit callback supplied')
+        onCommitCallbacks.push(cb)
+      },
+      onError: (cb: Function) => {
+        if (typeof cb !== 'function')
+          throw new Error('Non-function onError callback supplied')
+        onErrorCallbacks.push(cb)
+      },
+      onComplete: (cb: Function) => {
+        if (typeof cb !== 'function')
+          throw new Error('Non-function onComplete callback supplied')
+        onCompleteCallbacks.push(cb)
       },
     }
     await Promise.resolve(operation(transactionDB))
@@ -293,11 +305,14 @@ export class PostgresConnector extends DB {
     COMMIT;`
     try {
       await this.db.query(transactionSql)
-      for (const cb of onCommittedCallbacks) {
+      for (const cb of [...onCommitCallbacks, ...onCompleteCallbacks]) {
         cb()
       }
     } catch (err) {
       await this.db.query('ROLLBACK;')
+      for (const cb of [...onErrorCallbacks, ...onCompleteCallbacks]) {
+        cb()
+      }
       throw err
     }
   }

--- a/packages/database/src/connectors/sqlite-memory.ts
+++ b/packages/database/src/connectors/sqlite-memory.ts
@@ -53,7 +53,9 @@ export class SQLiteMemoryConnector extends DB {
   }
 
   async create(collection: string, _doc: any | any): Promise<any> {
-    return this.lock.acquire('db', async () => this._create(collection, _doc))
+    return this.lock.acquire('write', async () =>
+      this._create(collection, _doc),
+    )
   }
 
   private async _create(collection: string, _doc: any | any): Promise<any> {
@@ -73,7 +75,7 @@ export class SQLiteMemoryConnector extends DB {
   }
 
   async findOne(collection: string, options: FindOneOptions) {
-    return this.lock.acquire('db', async () =>
+    return this.lock.acquire('read', async () =>
       this._findOne(collection, options),
     )
   }
@@ -140,7 +142,7 @@ export class SQLiteMemoryConnector extends DB {
   }
 
   async findMany(collection: string, options: FindManyOptions) {
-    return this.lock.acquire('db', async () =>
+    return this.lock.acquire('read', async () =>
       this._findMany(collection, options),
     )
   }
@@ -186,7 +188,7 @@ export class SQLiteMemoryConnector extends DB {
   }
 
   async count(collection: string, where: WhereClause) {
-    return this.lock.acquire('db', async () => this._count(collection, where))
+    return this.lock.acquire('read', async () => this._count(collection, where))
   }
 
   async _count(collection: string, where: WhereClause) {
@@ -198,7 +200,7 @@ export class SQLiteMemoryConnector extends DB {
   }
 
   async update(collection: string, options: UpdateOptions) {
-    return this.lock.acquire('db', async () =>
+    return this.lock.acquire('write', async () =>
       this._update(collection, options),
     )
   }
@@ -214,7 +216,7 @@ export class SQLiteMemoryConnector extends DB {
   }
 
   async upsert(collection: string, options: UpsertOptions) {
-    return this.lock.acquire('db', async () =>
+    return this.lock.acquire('write', async () =>
       this._upsert(collection, options),
     )
   }
@@ -233,7 +235,7 @@ export class SQLiteMemoryConnector extends DB {
   }
 
   async delete(collection: string, options: DeleteManyOptions) {
-    return this.lock.acquire('db', async () =>
+    return this.lock.acquire('write', async () =>
       this._deleteMany(collection, options),
     )
   }
@@ -247,7 +249,7 @@ export class SQLiteMemoryConnector extends DB {
   }
 
   async transaction(operation: (db: TransactionDB) => void) {
-    return this.lock.acquire('db', async () => this._transaction(operation))
+    return this.lock.acquire('write', async () => this._transaction(operation))
   }
 
   // Allow only updates, upserts, deletes, and creates

--- a/packages/database/src/connectors/sqlite.ts
+++ b/packages/database/src/connectors/sqlite.ts
@@ -66,7 +66,9 @@ export class SQLiteConnector extends DB {
   }
 
   async create(collection: string, _doc: any | any): Promise<any> {
-    return this.lock.acquire('db', async () => this._create(collection, _doc))
+    return this.lock.acquire('write', async () =>
+      this._create(collection, _doc),
+    )
   }
 
   private async _create(collection: string, _doc: any | any): Promise<any> {
@@ -89,7 +91,7 @@ export class SQLiteConnector extends DB {
   }
 
   async findOne(collection: string, options: FindOneOptions) {
-    return this.lock.acquire('db', async () =>
+    return this.lock.acquire('read', async () =>
       this._findOne(collection, options),
     )
   }
@@ -156,7 +158,7 @@ export class SQLiteConnector extends DB {
   }
 
   async findMany(collection: string, options: FindManyOptions) {
-    return this.lock.acquire('db', async () =>
+    return this.lock.acquire('read', async () =>
       this._findMany(collection, options),
     )
   }
@@ -192,7 +194,7 @@ export class SQLiteConnector extends DB {
   }
 
   async count(collection: string, where: WhereClause) {
-    return this.lock.acquire('db', async () => this._count(collection, where))
+    return this.lock.acquire('read', async () => this._count(collection, where))
   }
 
   async _count(collection: string, where: WhereClause) {
@@ -204,7 +206,7 @@ export class SQLiteConnector extends DB {
   }
 
   async update(collection: string, options: UpdateOptions) {
-    return this.lock.acquire('db', async () =>
+    return this.lock.acquire('write', async () =>
       this._update(collection, options),
     )
   }
@@ -220,7 +222,7 @@ export class SQLiteConnector extends DB {
   }
 
   async upsert(collection: string, options: UpsertOptions) {
-    return this.lock.acquire('db', async () =>
+    return this.lock.acquire('write', async () =>
       this._upsert(collection, options),
     )
   }
@@ -239,7 +241,7 @@ export class SQLiteConnector extends DB {
   }
 
   async delete(collection: string, options: DeleteManyOptions) {
-    return this.lock.acquire('db', async () =>
+    return this.lock.acquire('write', async () =>
       this._deleteMany(collection, options),
     )
   }
@@ -253,7 +255,7 @@ export class SQLiteConnector extends DB {
   }
 
   async transaction(operation: (db: TransactionDB) => void) {
-    return this.lock.acquire('db', async () => this._transaction(operation))
+    return this.lock.acquire('write', async () => this._transaction(operation))
   }
 
   // Allow only updates, upserts, deletes, and creates

--- a/packages/database/src/connectors/sqlite.ts
+++ b/packages/database/src/connectors/sqlite.ts
@@ -262,6 +262,7 @@ export class SQLiteConnector extends DB {
   private async _transaction(operation: (db: TransactionDB) => void) {
     if (typeof operation !== 'function') throw new Error('Invalid operation')
     const sqlOperations = [] as string[]
+    const onCommittedCallbacks = [] as Function[]
     const transactionDB = {
       create: (collection: string, _doc: any) => {
         const table = this.schema[collection]
@@ -289,6 +290,11 @@ export class SQLiteConnector extends DB {
         const sql = upsertSql(table, options)
         sqlOperations.push(sql)
       },
+      onCommitted: (cb: Function) => {
+        if (typeof cb !== 'function')
+          throw new Error('Non-function onCommitted callback supplied')
+        onCommittedCallbacks.push(cb)
+      },
     }
     await Promise.resolve(operation(transactionDB))
     // now apply the transaction
@@ -297,6 +303,9 @@ export class SQLiteConnector extends DB {
     COMMIT;`
     try {
       await this.db.exec(transactionSql)
+      for (const cb of onCommittedCallbacks) {
+        cb()
+      }
     } catch (err) {
       await this.db.exec('ROLLBACK;')
       throw err

--- a/packages/database/src/connectors/sqlite.ts
+++ b/packages/database/src/connectors/sqlite.ts
@@ -262,7 +262,9 @@ export class SQLiteConnector extends DB {
   private async _transaction(operation: (db: TransactionDB) => void) {
     if (typeof operation !== 'function') throw new Error('Invalid operation')
     const sqlOperations = [] as string[]
-    const onCommittedCallbacks = [] as Function[]
+    const onCommitCallbacks = [] as Function[]
+    const onErrorCallbacks = [] as Function[]
+    const onCompleteCallbacks = [] as Function[]
     const transactionDB = {
       create: (collection: string, _doc: any) => {
         const table = this.schema[collection]
@@ -290,10 +292,20 @@ export class SQLiteConnector extends DB {
         const sql = upsertSql(table, options)
         sqlOperations.push(sql)
       },
-      onCommitted: (cb: Function) => {
+      onCommit: (cb: Function) => {
         if (typeof cb !== 'function')
-          throw new Error('Non-function onCommitted callback supplied')
-        onCommittedCallbacks.push(cb)
+          throw new Error('Non-function onCommit callback supplied')
+        onCommitCallbacks.push(cb)
+      },
+      onError: (cb: Function) => {
+        if (typeof cb !== 'function')
+          throw new Error('Non-function onError callback supplied')
+        onErrorCallbacks.push(cb)
+      },
+      onComplete: (cb: Function) => {
+        if (typeof cb !== 'function')
+          throw new Error('Non-function onComplete callback supplied')
+        onCompleteCallbacks.push(cb)
       },
     }
     await Promise.resolve(operation(transactionDB))
@@ -303,11 +315,14 @@ export class SQLiteConnector extends DB {
     COMMIT;`
     try {
       await this.db.exec(transactionSql)
-      for (const cb of onCommittedCallbacks) {
+      for (const cb of [...onCommitCallbacks, ...onCompleteCallbacks]) {
         cb()
       }
     } catch (err) {
       await this.db.exec('ROLLBACK;')
+      for (const cb of [...onErrorCallbacks, ...onCompleteCallbacks]) {
+        cb()
+      }
       throw err
     }
   }

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -123,7 +123,9 @@ export interface TransactionDB {
   upsert: (collection: string, options: UpsertOptions) => void
   // deleteOne: (collection: string, options: FindOneOptions) => void
   delete: (collection: string, options: DeleteManyOptions) => void
-  onCommitted: (onComplete: Function) => void
+  onCommit: (callback: Function) => void
+  onError: (callback: Function) => void
+  onComplete: (callback: Function) => void
 }
 
 export type SchemaTable = {

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -123,6 +123,7 @@ export interface TransactionDB {
   upsert: (collection: string, options: UpsertOptions) => void
   // deleteOne: (collection: string, options: FindOneOptions) => void
   delete: (collection: string, options: DeleteManyOptions) => void
+  onCommitted: (onComplete: Function) => void
 }
 
 export type SchemaTable = {

--- a/packages/database/tests/database/transaction.ts
+++ b/packages/database/tests/database/transaction.ts
@@ -82,35 +82,94 @@ export default function(this: { db: DB }) {
     assert.equal(count, 0)
   })
 
-  test('should execute onCommitted callback', async () => {
+  test('should execute transactions callbacks on success', async () => {
     const table = 'TableThree'
     let committed = false
+    let completed = false
+    let errored = false
     const transactionPromise = this.db.transaction(db => {
       db.create(table, {
         id: 'test0',
       })
-      db.onCommitted(() => {
+      db.onCommit(() => {
         committed = true
+      })
+      db.onComplete(() => {
+        completed = true
+      })
+      db.onError(() => {
+        errored = true
       })
     })
     assert(!committed)
+    assert(!completed)
+    assert(!errored)
     await transactionPromise
     assert(committed)
+    assert(completed)
+    assert(!errored)
   })
 
-  test('should fail to register non-function onCommitted callback', async () => {
+  test('should execute transactions callbacks on error', async () => {
+    const table = 'TableThree'
+    let committed = false
+    let completed = false
+    let errored = false
+    const transactionPromise = this.db.transaction(db => {
+      db.create(table, {
+        id: null,
+      })
+      db.onCommit(() => {
+        committed = true
+      })
+      db.onComplete(() => {
+        completed = true
+      })
+      db.onError(() => {
+        errored = true
+      })
+    })
+    assert(!committed)
+    assert(!completed)
+    assert(!errored)
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    await transactionPromise.catch(() => {})
+    assert(!committed)
+    assert(completed)
+    assert(errored)
+  })
+
+  test('should fail to register non-function callbacks', async () => {
     const table = 'TableThree'
     const transactionPromise = this.db.transaction(db => {
       db.create(table, {
         id: 'test0',
       })
       try {
-        db.onCommitted({} as any)
+        db.onCommit({} as any)
         assert(false)
       } catch (err) {
         assert.equal(
           err.toString(),
-          'Error: Non-function onCommitted callback supplied',
+          'Error: Non-function onCommit callback supplied',
+        )
+      }
+      try {
+        db.onError({} as any)
+        assert(false)
+      } catch (err) {
+        assert.equal(
+          err.toString(),
+          'Error: Non-function onError callback supplied',
+        )
+      }
+      try {
+        db.onComplete({} as any)
+        assert(false)
+      } catch (err) {
+        assert.equal(
+          err.toString(),
+          'Error: Non-function onComplete callback supplied',
         )
       }
     })

--- a/packages/database/tests/database/transaction.ts
+++ b/packages/database/tests/database/transaction.ts
@@ -81,4 +81,39 @@ export default function(this: { db: DB }) {
     const count = await this.db.count(table, {})
     assert.equal(count, 0)
   })
+
+  test('should execute onCommitted callback', async () => {
+    const table = 'TableThree'
+    let committed = false
+    const transactionPromise = this.db.transaction(db => {
+      db.create(table, {
+        id: 'test0',
+      })
+      db.onCommitted(() => {
+        committed = true
+      })
+    })
+    assert(!committed)
+    await transactionPromise
+    assert(committed)
+  })
+
+  test('should fail to register non-function onCommitted callback', async () => {
+    const table = 'TableThree'
+    const transactionPromise = this.db.transaction(db => {
+      db.create(table, {
+        id: 'test0',
+      })
+      try {
+        db.onCommitted({} as any)
+        assert(false)
+      } catch (err) {
+        assert.equal(
+          err.toString(),
+          'Error: Non-function onCommitted callback supplied',
+        )
+      }
+    })
+    await transactionPromise
+  })
 }

--- a/packages/dataset/src/testset-zktxs.ts
+++ b/packages/dataset/src/testset-zktxs.ts
@@ -35,20 +35,25 @@ export async function loadGrove(db: DB): Promise<{ grove: Grove }> {
   const latestTree = grove.utxoTree
   const size = latestTree ? latestTree.latestLeafIndex() : Fp.zero
   if (size.eqn(0)) {
-    await grove.applyGrovePatch({
-      utxos: [
-        utxos.utxo1_in_1,
-        utxos.utxo2_1_in_1,
-        utxos.utxo2_2_in_1,
-        utxos.utxo3_in_1,
-        utxos.utxo3_in_2,
-        utxos.utxo3_in_3,
-        utxos.utxo4_in_1,
-        utxos.utxo4_in_2,
-        utxos.utxo4_in_3,
-      ].map(utxo => ({ hash: utxo.hash(), note: utxo })),
-      withdrawals: [],
-      nullifiers: [],
+    await db.transaction(async db => {
+      await grove.applyGrovePatch(
+        {
+          utxos: [
+            utxos.utxo1_in_1,
+            utxos.utxo2_1_in_1,
+            utxos.utxo2_2_in_1,
+            utxos.utxo3_in_1,
+            utxos.utxo3_in_2,
+            utxos.utxo3_in_3,
+            utxos.utxo4_in_1,
+            utxos.utxo4_in_2,
+            utxos.utxo4_in_3,
+          ].map(utxo => ({ hash: utxo.hash(), note: utxo })),
+          withdrawals: [],
+          nullifiers: [],
+        },
+        db,
+      )
     })
   }
   return { grove }

--- a/packages/integration-test/tests/index.test.ts
+++ b/packages/integration-test/tests/index.test.ts
@@ -66,12 +66,14 @@ import {
   testRound3SendZkTxsToCoordinator,
   testRound3NewBlockProposalAndSlashing,
 } from './cases/9_zk_tx_round_3'
+// import { attachConsoleLogToPino } from '~utils'
 
 process.env.DEFAULT_COORDINATOR = 'http://localhost:8888'
 
 jestExtendToCompareBigNumber(expect)
 
 describe('testnet', () => {
+  // attachConsoleLogToPino()
   let context!: Context
   const ctx = () => context
   beforeAll(async () => {

--- a/packages/tree/src/light-rollup-tree.ts
+++ b/packages/tree/src/light-rollup-tree.ts
@@ -9,6 +9,7 @@ import {
   DB,
   TreeSpecies,
   getCachedSiblings,
+  cacheTreeNode,
   TransactionDB,
 } from '@zkopru/database'
 import { Hasher } from './hasher'
@@ -426,6 +427,11 @@ export abstract class LightRollUpTree<T extends Fp | BN> {
     })
     // update cached nodes
     for (const nodeIndex of Object.keys(cached)) {
+      cacheTreeNode(this.metadata.id, nodeIndex, {
+        treeId: this.metadata.id,
+        nodeIndex,
+        value: cached[nodeIndex],
+      })
       db.upsert('TreeNode', {
         where: {
           treeId: this.metadata.id,

--- a/packages/tree/src/light-rollup-tree.ts
+++ b/packages/tree/src/light-rollup-tree.ts
@@ -448,7 +448,7 @@ export abstract class LightRollUpTree<T extends Fp | BN> {
         },
       })
     }
-    db.onCommitted(() => clearTreeCache())
+    db.onComplete(() => clearTreeCache())
     return {
       root,
       index: end,

--- a/packages/tree/src/light-rollup-tree.ts
+++ b/packages/tree/src/light-rollup-tree.ts
@@ -10,6 +10,7 @@ import {
   TreeSpecies,
   getCachedSiblings,
   cacheTreeNode,
+  clearTreeCache,
   TransactionDB,
 } from '@zkopru/database'
 import { Hasher } from './hasher'
@@ -447,6 +448,7 @@ export abstract class LightRollUpTree<T extends Fp | BN> {
         },
       })
     }
+    db.onCommitted(() => clearTreeCache())
     return {
       root,
       index: end,

--- a/packages/tree/src/nullifier-tree.ts
+++ b/packages/tree/src/nullifier-tree.ts
@@ -10,6 +10,7 @@ import {
   NULLIFIER_TREE_ID,
   getCachedSiblings,
   cacheTreeNode,
+  clearTreeCache,
   TransactionDB,
 } from '@zkopru/database'
 import { Hasher, genesisRoot } from './hasher'
@@ -269,6 +270,7 @@ export class NullifierTree implements SMT<BN> {
         },
       })
     }
+    db.onCommitted(() => clearTreeCache())
     const newRoot = updatedNodes[hexify(new BN(1))]
     logger.trace(`setting new root - ${newRoot}`)
     this.rootNode = newRoot

--- a/packages/tree/src/nullifier-tree.ts
+++ b/packages/tree/src/nullifier-tree.ts
@@ -9,6 +9,7 @@ import {
   TreeNode,
   NULLIFIER_TREE_ID,
   getCachedSiblings,
+  cacheTreeNode,
   TransactionDB,
 } from '@zkopru/database'
 import { Hasher, genesisRoot } from './hasher'
@@ -250,6 +251,11 @@ export class NullifierTree implements SMT<BN> {
     const { updatedNodes } = await this.dryRun(leaves, option)
     // need batch query here..
     for (const nodeIndex of Object.keys(updatedNodes)) {
+      cacheTreeNode(NULLIFIER_TREE_ID, nodeIndex, {
+        treeId: NULLIFIER_TREE_ID,
+        nodeIndex,
+        value: hexify(updatedNodes[nodeIndex]),
+      })
       db.upsert('TreeNode', {
         where: {
           treeId: NULLIFIER_TREE_ID,

--- a/packages/tree/src/nullifier-tree.ts
+++ b/packages/tree/src/nullifier-tree.ts
@@ -270,7 +270,7 @@ export class NullifierTree implements SMT<BN> {
         },
       })
     }
-    db.onCommitted(() => clearTreeCache())
+    db.onComplete(() => clearTreeCache())
     const newRoot = updatedNodes[hexify(new BN(1))]
     logger.trace(`setting new root - ${newRoot}`)
     this.rootNode = newRoot

--- a/packages/tree/tests/unit/utxo-tree.test.ts
+++ b/packages/tree/tests/unit/utxo-tree.test.ts
@@ -30,7 +30,7 @@ describe('utxo tree unit test', () => {
     beforeAll(async () => {
       prevRoot = utxoTree.root()
       const items: Leaf<Fp>[] = [{ hash: Fp.from(1) }, { hash: Fp.from(2) }]
-      result = await utxoTree.dryAppend(...items)
+      result = await utxoTree.dryAppend(items)
     })
     it('should not update its root', () => {
       expect(utxoTree.root().eq(prevRoot)).toBe(true)
@@ -56,8 +56,10 @@ describe('utxo tree unit test', () => {
     beforeAll(async () => {
       prevRoot = utxoTree.root()
       const items: Leaf<Fp>[] = [{ hash: Fp.from(1) }, { hash: Fp.from(2) }]
-      dryResult = await utxoTree.dryAppend(...items)
-      result = await utxoTree.append(...items)
+      dryResult = await utxoTree.dryAppend(items)
+      await mockup.transaction(async db => {
+        result = await utxoTree.append(items, db)
+      })
     }, 30000)
     it('should update its root and its value should equal to the dry run', () => {
       expect(result.root.eq(prevRoot)).toBe(false)
@@ -80,7 +82,7 @@ describe('utxo tree unit test', () => {
       note,
     }))
     beforeAll(async () => {
-      await utxoTree.append(...items)
+      await mockup.transaction(async db => utxoTree.append(items, db))
       utxoTree.updatePubKeys([accounts.alice.zkAddress])
     })
     it("should track Alice's utxos while not tracking Bob's", async () => {

--- a/packages/tree/tests/unit/withdrawal-tree.test.ts
+++ b/packages/tree/tests/unit/withdrawal-tree.test.ts
@@ -67,7 +67,7 @@ describe('withdrawal tree unit test', () => {
     beforeAll(async () => {
       prevRoot = withdrawalTree.root()
       const items: Leaf<BN>[] = [{ hash: toBN(1) }, { hash: toBN(2) }]
-      result = await withdrawalTree.dryAppend(...items)
+      result = await withdrawalTree.dryAppend(items)
     })
     it('should not update its root', () => {
       expect(withdrawalTree.root().eq(prevRoot)).toBe(true)
@@ -93,8 +93,10 @@ describe('withdrawal tree unit test', () => {
     it('should update its root and its value should equal to the dry run', async () => {
       prevRoot = withdrawalTree.root()
       const items: Leaf<BN>[] = [{ hash: toBN(1) }, { hash: toBN(2) }]
-      dryResult = await withdrawalTree.dryAppend(...items)
-      result = await withdrawalTree.append(...items)
+      dryResult = await withdrawalTree.dryAppend(items)
+      await mockup.transaction(async db => {
+        result = await withdrawalTree.append(items, db)
+      })
       expect(result.root.eq(prevRoot)).toBe(false)
       expect(result.root.eq(dryResult.root)).toBe(true)
       expect(result.index.eq(dryResult.index)).toBe(true)
@@ -117,7 +119,7 @@ describe('withdrawal tree unit test', () => {
     }))
     it("should track Alice's utxos while not tracking Bob's", async () => {
       withdrawalTree.updateAddresses(addresses)
-      await withdrawalTree.append(...items)
+      await mockup.transaction(async db => withdrawalTree.append(items, db))
       const proof = await withdrawalTree.merkleProof({
         hash: items[0].hash,
       })

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -6,7 +6,7 @@ import { Bytes32, Uint256, Address } from 'soltypes'
 import BN from 'bn.js'
 import axios from 'axios'
 
-export { logger, logStream } from './logger'
+export { logger, logStream, attachConsoleLogToPino } from './logger'
 
 export { PromptApp } from './prompt'
 

--- a/packages/zk-wizard/tests/unit/index.test.ts
+++ b/packages/zk-wizard/tests/unit/index.test.ts
@@ -31,21 +31,26 @@ async function loadGrove(db: DB): Promise<{ grove: Grove }> {
   const latestTree = grove.utxoTree
   const size = latestTree ? latestTree.latestLeafIndex() : Fp.zero
   if (size.eqn(0)) {
-    await grove.applyGrovePatch({
-      utxos: [
-        utxos.utxo1_in_1,
-        utxos.utxo2_1_in_1,
-        utxos.utxo2_2_in_1,
-        utxos.utxo3_in_1,
-        utxos.utxo3_in_2,
-        utxos.utxo3_in_3,
-        utxos.utxo4_in_1,
-        utxos.utxo4_in_2,
-        utxos.utxo4_in_3,
-      ].map(utxo => ({ hash: utxo.hash(), note: utxo })),
-      withdrawals: [],
-      nullifiers: [],
-    })
+    await db.transaction(txdb =>
+      grove.applyGrovePatch(
+        {
+          utxos: [
+            utxos.utxo1_in_1,
+            utxos.utxo2_1_in_1,
+            utxos.utxo2_2_in_1,
+            utxos.utxo3_in_1,
+            utxos.utxo3_in_2,
+            utxos.utxo3_in_3,
+            utxos.utxo4_in_1,
+            utxos.utxo4_in_2,
+            utxos.utxo4_in_3,
+          ].map(utxo => ({ hash: utxo.hash(), note: utxo })),
+          withdrawals: [],
+          nullifiers: [],
+        },
+        txdb,
+      ),
+    )
   }
   return { grove }
 }


### PR DESCRIPTION
Performs block processing operations in a single database transaction so a power failure or abnormal exit condition will not corrupt the database.

Closes #222 

Refactors some tree operations to accept a `TransactionDB`. This lets them be a part of a larger transaction. The downside is when they are used independently the call has to be manually wrapped in a db transaction. I thought about making the `TransactionDB` argument optional (and auto-generate a transaction when needed) but decided it was unnecessary.

This also adds an optional in-memory cache to the tree. This is necessary because a transaction doesn't modify the database until it is committed but some operations expect the changes to be in the database. I've implemented it as an in-memory cache that is cleared when the transaction is completed. It's only used in the `block-processor`, it should not affect any other parts of the codebase (though it could be used elsewhere). I'm not a big fan of this in-memory cache but it was the cleanest/simplest solution I found.

[Cache implementation](https://github.com/zkopru-network/zkopru/blob/atomic-sync/packages/database/src/preset.ts#L13)
[Cache use](https://github.com/zkopru-network/zkopru/blob/atomic-sync/packages/tree/src/light-rollup-tree.ts#L431)

Also adds an `onCommit`/`onError`/`onComplete` callbacks to the transaction db object.