### PR TITLE
Fix/224

### DIFF
--- a/packages/contracts/contracts/zkopru/controllers/Coordinatable.sol
+++ b/packages/contracts/contracts/zkopru/controllers/Coordinatable.sol
@@ -196,13 +196,18 @@ contract Coordinatable is Storage {
             Storage.chain.committedDeposits[massDepositHash] -= 1;
         }
 
-        // Record mass migrations and collect fees.
-        require(
-            Storage.chain.migrationRoots[finalization.header.migrationRoot] ==
-                false,
-            "Migration root already exists."
-        );
-        Storage.chain.migrationRoots[finalization.header.migrationRoot] = true;
+        // Record mass migrations
+        if (finalization.header.migrationRoot != bytes32(0)) {
+            require(
+                Storage.chain.migrationRoots[
+                    finalization.header.migrationRoot
+                ] == false,
+                "Migration root already exists."
+            );
+            Storage.chain.migrationRoots[
+                finalization.header.migrationRoot
+            ] = true;
+        }
 
         // Give fee to the proposer
         Proposer storage proposer =


### PR DESCRIPTION
Thanks for the issue raising. Fixed the contract code and it seems to work well now.
As you pointed out the problem was when the migration root is 0x00000...0000 when we propose blocks without any migration objects. Only the extremely rare case of hash collision will cause this bug in the future. BTW this case also can be prevented by checking the existing migration root before proposing or repropose another sibling block if that's stuck for the finalization.