### PR TITLE
Reorg revert handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
           name: Generate Block Data
           command: |
             cd packages/contracts
-            yarn testblock:generate --scope=@zkopru/contracts
+            DEBUG=1 yarn testblock:generate --scope=@zkopru/contracts
       - run:
           name: Contract Tests
           command: yarn test --scope=@zkopru/contracts
@@ -209,4 +209,4 @@ jobs:
       - run:
           name: Integration Tests
           no_output_timeout: 45m
-          command: yarn test --scope=@zkopru/integration-test
+          command: DEBUG=1 yarn test --scope=@zkopru/integration-test

--- a/packages/cli/src/apps/coordinator/configurator/config-prompts/load-database.ts
+++ b/packages/cli/src/apps/coordinator/configurator/config-prompts/load-database.ts
@@ -6,6 +6,7 @@ import {
   PostgresConnector,
   schema,
   initDB,
+  BlockCache,
 } from '@zkopru/database/dist/node'
 import { L1Contract } from '@zkopru/core'
 import Configurator, { Context, Menu } from '../configurator'
@@ -120,7 +121,11 @@ export default class LoadDatabase extends Configurator {
       new L1Contract(context.web3, this.base.address),
     )
     return {
-      context: { ...context, db: database },
+      context: {
+        ...context,
+        db: database,
+        blockCache: new BlockCache(context.web3, database),
+      },
       next: Menu.LOAD_COORDINATOR,
     }
   }

--- a/packages/cli/src/apps/coordinator/configurator/config-prompts/load-database.ts
+++ b/packages/cli/src/apps/coordinator/configurator/config-prompts/load-database.ts
@@ -6,7 +6,6 @@ import {
   PostgresConnector,
   schema,
   initDB,
-  BlockCache,
 } from '@zkopru/database/dist/node'
 import { L1Contract } from '@zkopru/core'
 import Configurator, { Context, Menu } from '../configurator'
@@ -124,7 +123,6 @@ export default class LoadDatabase extends Configurator {
       context: {
         ...context,
         db: database,
-        blockCache: new BlockCache(context.web3, database),
       },
       next: Menu.LOAD_COORDINATOR,
     }

--- a/packages/cli/src/apps/coordinator/configurator/configurator.ts
+++ b/packages/cli/src/apps/coordinator/configurator/configurator.ts
@@ -1,7 +1,7 @@
 import Web3 from 'web3'
 import { Coordinator } from '@zkopru/coordinator'
 import { NetworkStatus } from '@zkopru/core'
-import { DB, BlockCache } from '@zkopru/database'
+import { DB } from '@zkopru/database'
 import { PromptApp } from '@zkopru/utils'
 import { Account, WebsocketProvider, EncryptedKeystoreV3Json } from 'web3-core'
 
@@ -41,7 +41,6 @@ export interface Context {
   web3?: Web3
   provider?: WebsocketProvider
   db?: DB
-  blockCache?: BlockCache
   coordinator?: Coordinator
   keystore?: EncryptedKeystoreV3Json
   account?: Account

--- a/packages/cli/src/apps/coordinator/configurator/configurator.ts
+++ b/packages/cli/src/apps/coordinator/configurator/configurator.ts
@@ -1,7 +1,7 @@
 import Web3 from 'web3'
 import { Coordinator } from '@zkopru/coordinator'
 import { NetworkStatus } from '@zkopru/core'
-import { DB } from '@zkopru/database'
+import { DB, BlockCache } from '@zkopru/database'
 import { PromptApp } from '@zkopru/utils'
 import { Account, WebsocketProvider, EncryptedKeystoreV3Json } from 'web3-core'
 
@@ -41,6 +41,7 @@ export interface Context {
   web3?: Web3
   provider?: WebsocketProvider
   db?: DB
+  blockCache?: BlockCache
   coordinator?: Coordinator
   keystore?: EncryptedKeystoreV3Json
   account?: Account

--- a/packages/contracts/utils/testblock-generator.js
+++ b/packages/contracts/utils/testblock-generator.js
@@ -28,10 +28,11 @@ const outputPath = path.join(__dirname, "../test-cases");
 process.env.BLOCK_CONFIRMATIONS = "0";
 
 (async () => {
+  let context;
   try {
     if (process.env.DEBUG) attachConsoleLogToPino();
     console.log(`Generating test block, writing to "${outputPath}"`);
-    const context = await initContext();
+    context = await initContext();
     console.log("Registering vks");
     await registerVks(context);
     console.log("Finishing setup");

--- a/packages/contracts/utils/testblock-generator.js
+++ b/packages/contracts/utils/testblock-generator.js
@@ -25,6 +25,8 @@ const { TxBuilder, Utxo, ZkTx, ZkAddress } = require("~transaction");
 
 const outputPath = path.join(__dirname, "../test-cases");
 
+process.env.BLOCK_CONFIRMATIONS = "0";
+
 (async () => {
   try {
     if (process.env.DEBUG) attachConsoleLogToPino();

--- a/packages/core/src/node/block-processor.ts
+++ b/packages/core/src/node/block-processor.ts
@@ -3,6 +3,7 @@ import { ZkViewer } from '@zkopru/account'
 import { Fp } from '@zkopru/babyjubjub'
 import {
   DB,
+  BlockCache,
   Proposal,
   MassDeposit as MassDepositSql,
   TransactionDB,
@@ -48,6 +49,8 @@ export declare interface BlockProcessor {
 export class BlockProcessor extends EventEmitter {
   db: DB
 
+  blockCache: BlockCache
+
   layer2: L2Chain
 
   tracker: Tracker
@@ -60,17 +63,20 @@ export class BlockProcessor extends EventEmitter {
 
   constructor({
     db,
+    blockCache,
     l2Chain,
     tracker,
     validator,
   }: {
     db: DB
+    blockCache: BlockCache
     l2Chain: L2Chain
     tracker: Tracker
     validator: Validator
   }) {
     super()
     this.db = db
+    this.blockCache = blockCache
     this.layer2 = l2Chain
     this.tracker = tracker
     this.validator = validator

--- a/packages/core/src/node/synchronizer.ts
+++ b/packages/core/src/node/synchronizer.ts
@@ -461,33 +461,29 @@ export class Synchronizer extends EventEmitter {
 
         logger.debug(`slashed hash@!${hash}`)
         logger.debug(`${JSON.stringify(event.returnValues)}`)
-        await this.blockCache.upsertCache(
-          'Slash',
-          {
-            where: { hash },
-            create: {
-              proposer,
-              reason,
-              executionTx: transactionHash,
-              slashedAt: blockNumber,
-              hash,
-            },
-            update: {
-              hash,
-              proposer,
-              reason,
-              executionTx: transactionHash,
-              slashedAt: blockNumber,
-            },
-          },
-          blockNumber,
-          event.blockHash,
-        )
-        await this.blockCache.updateCache(
-          'Tx',
-          {
-            where: { blockHash: hash },
-            update: { slashed: true },
+        await this.blockCache.transactionCache(
+          db => {
+            db.upsert('Slash', {
+              where: { hash },
+              create: {
+                proposer,
+                reason,
+                executionTx: transactionHash,
+                slashedAt: blockNumber,
+                hash,
+              },
+              update: {
+                hash,
+                proposer,
+                reason,
+                executionTx: transactionHash,
+                slashedAt: blockNumber,
+              },
+            })
+            db.update('Tx', {
+              where: { blockHash: hash },
+              update: { slashed: true },
+            })
           },
           blockNumber,
           event.blockHash,

--- a/packages/core/src/node/synchronizer.ts
+++ b/packages/core/src/node/synchronizer.ts
@@ -310,15 +310,20 @@ export class Synchronizer extends EventEmitter {
           blockNumber,
         }
         logger.info(`synchronizer.js: NewDeposit(${deposit.note})`)
-        await this.blockCache.upsertCache(blockNumber, 'Deposit', {
-          where: { note: deposit.note },
-          update: deposit,
-          create: deposit,
-        })
+        await this.blockCache.upsertCache(
+          'Deposit',
+          {
+            where: { note: deposit.note },
+            update: deposit,
+            create: deposit,
+          },
+          blockNumber,
+          event.blockHash,
+        )
         if (cb) cb(deposit)
       })
       .on('changed', event => {
-        // TODO
+        this.blockCache.clearChangesForBlockHash(event.blockHash)
         logger.info(`synchronizer.js: Deposit Event changed`, event)
       })
       .on('error', event => {
@@ -361,16 +366,21 @@ export class Synchronizer extends EventEmitter {
           `Massdeposit: index ${massDeposit.index} / merged: ${massDeposit.merged} / fee: ${massDeposit.fee}`,
         )
         logger.info('massdeposit commit is', massDeposit)
-        await this.blockCache.upsertCache(blockNumber, 'MassDeposit', {
-          where: { index: massDeposit.index },
-          create: massDeposit,
-          update: {},
-        })
+        await this.blockCache.upsertCache(
+          'MassDeposit',
+          {
+            where: { index: massDeposit.index },
+            create: massDeposit,
+            update: {},
+          },
+          blockNumber,
+          event.blockHash,
+        )
         if (cb) cb(massDeposit)
         logger.info('massdeposit commit succeeded')
       })
       .on('changed', event => {
-        // TODO
+        this.blockCache.clearChangesForBlockHash(event.blockHash)
         logger.info(`synchronizer.js: MassDeposit Event changed`, event)
       })
       .on('error', event => {
@@ -407,15 +417,20 @@ export class Synchronizer extends EventEmitter {
           proposedAt: blockNumber,
           proposalTx: transactionHash,
         }
-        await this.blockCache.upsertCache(newProposal.proposedAt, 'Proposal', {
-          where: { hash: newProposal.hash },
-          create: newProposal,
-          update: newProposal,
-        })
+        await this.blockCache.upsertCache(
+          'Proposal',
+          {
+            where: { hash: newProposal.hash },
+            create: newProposal,
+            update: newProposal,
+          },
+          blockNumber,
+          event.blockHash,
+        )
         if (cb) cb(blockHash)
       })
       .on('changed', event => {
-        // TODO
+        this.blockCache.clearChangesForBlockHash(event.blockHash)
         logger.info(`synchronizer.js: NewProposal Event changed`, event)
       })
       .on('error', err => {
@@ -446,31 +461,41 @@ export class Synchronizer extends EventEmitter {
 
         logger.debug(`slashed hash@!${hash}`)
         logger.debug(`${JSON.stringify(event.returnValues)}`)
-        await this.blockCache.upsertCache(blockNumber, 'Slash', {
-          where: { hash },
-          create: {
-            proposer,
-            reason,
-            executionTx: transactionHash,
-            slashedAt: blockNumber,
-            hash,
+        await this.blockCache.upsertCache(
+          'Slash',
+          {
+            where: { hash },
+            create: {
+              proposer,
+              reason,
+              executionTx: transactionHash,
+              slashedAt: blockNumber,
+              hash,
+            },
+            update: {
+              hash,
+              proposer,
+              reason,
+              executionTx: transactionHash,
+              slashedAt: blockNumber,
+            },
           },
-          update: {
-            hash,
-            proposer,
-            reason,
-            executionTx: transactionHash,
-            slashedAt: blockNumber,
+          blockNumber,
+          event.blockHash,
+        )
+        await this.blockCache.updateCache(
+          'Tx',
+          {
+            where: { blockHash: hash },
+            update: { slashed: true },
           },
-        })
-        await this.blockCache.updateCache(blockNumber, 'Tx', {
-          where: { blockHash: hash },
-          update: { slashed: true },
-        })
+          blockNumber,
+          event.blockHash,
+        )
         if (cb) cb(hash)
       })
       .on('changed', event => {
-        // TODO removed
+        this.blockCache.clearChangesForBlockHash(event.blockHash)
         logger.info(`synchronizer.js: Slash Event changed`, event)
       })
       .on('error', err => {
@@ -501,15 +526,20 @@ export class Synchronizer extends EventEmitter {
         const hash = Bytes32.from(blockHash).toString()
         logger.debug(`finalization hash@!${hash}`)
         logger.debug(`${JSON.stringify(event.returnValues)}`)
-        await this.blockCache.upsertCache(event.blockNumber, 'Proposal', {
-          where: { hash },
-          create: { hash, finalized: true },
-          update: { finalized: true },
-        })
+        await this.blockCache.upsertCache(
+          'Proposal',
+          {
+            where: { hash },
+            create: { hash, finalized: true },
+            update: { finalized: true },
+          },
+          event.blockNumber,
+          event.blockHash,
+        )
         if (cb) cb(blockHash)
       })
       .on('changed', event => {
-        // TODO removed
+        this.blockCache.clearChangesForBlockHash(event.blockHash)
         logger.info(`synchronizer.js: Finalization Event changed`, event)
       })
       .on('error', err => {

--- a/packages/core/src/node/zkopru-node.ts
+++ b/packages/core/src/node/zkopru-node.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { ZkAccount } from '@zkopru/account'
-import { DB } from '@zkopru/database'
+import { DB, BlockCache } from '@zkopru/database'
 import { Grove, poseidonHasher, keccakHasher } from '@zkopru/tree'
 import { logger } from '@zkopru/utils'
 import { L1Contract } from '../context/layer1'
@@ -15,6 +15,8 @@ export class ZkopruNode {
   running: boolean
 
   db: DB
+
+  blockCache: BlockCache
 
   tracker: Tracker
 
@@ -37,6 +39,7 @@ export class ZkopruNode {
 
   constructor({
     db,
+    blockCache,
     l1Contract,
     l2Chain,
     synchronizer,
@@ -46,6 +49,7 @@ export class ZkopruNode {
     bootstrapHelper,
   }: {
     db: DB
+    blockCache: BlockCache
     l1Contract: L1Contract
     l2Chain: L2Chain
     synchronizer: Synchronizer
@@ -55,6 +59,7 @@ export class ZkopruNode {
     bootstrapHelper?: BootstrapHelper
   }) {
     this.db = db
+    this.blockCache = blockCache
     this.tracker = tracker
     this.context = {
       layer1: l1Contract,

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -10,7 +10,9 @@ This is the interface for a `DB` object. This is the primary way to interact wit
 
 #### Where
 
-The where clause is used in many different queries. It allows matches based on simple property comparison, or more complex operators including `lt`, `lte`, `gt`, `gte`, and `ne` (not equal).
+The where clause is used in many different queries. It allows matches based on simple property comparison or more complex operators including `lt`, `lte`, `gt`, `gte`, and `ne` (not equal).
+
+A where clause may contain the top level keys `AND` or `OR`. Each may contain an array of where clauses to be combined using and/or logic respectively.
 
 A where clause using all possible comparison operators is shown below.
 
@@ -25,7 +27,7 @@ A where clause using all possible comparison operators is shown below.
     gt: 5, // requires that this field be greater than 5
     lt: 10, // multiple operators may be used, they are combined using AND logic
   },
-  // a top level key named OR allows you to specify conditions combined by or logic
+  // a top level key named OR allows you to specify conditions combined by OR logic
   OR: [
     {
       // This returns documents where 5 < integer2Field < 10 or integer2Field is 12
@@ -33,6 +35,15 @@ A where clause using all possible comparison operators is shown below.
     },
     {
       textField: 'another simple value'
+    }
+  ],
+  // a top level key named AND allows you to specify conditions combined by AND logic
+  AND: [
+    {
+      integer2Field: { gt: 10 },
+    },
+    {
+      integer2Field: { lt: 20 },
     }
   ]
 }

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -10,7 +10,7 @@ This is the interface for a `DB` object. This is the primary way to interact wit
 
 #### Where
 
-The where clause is used in many different queries. It allows matches based on simple property comparison or more complex operators including `lt`, `lte`, `gt`, `gte`, and `ne` (not equal).
+The where clause is used in many different queries. It allows matches based on simple property comparison or more complex operators including `lt`, `lte`, `gt`, `gte`, `ne` (not equal), and `nin` (not in array).
 
 A where clause may contain the top level keys `AND` or `OR`. Each may contain an array of where clauses to be combined using and/or logic respectively.
 
@@ -27,6 +27,7 @@ A where clause using all possible comparison operators is shown below.
     gt: 5, // requires that this field be greater than 5
     lt: 10, // multiple operators may be used, they are combined using AND logic
   },
+  textField2: { nin: [ 'not', 'these', 'words' ] },
   // a top level key named OR allows you to specify conditions combined by OR logic
   OR: [
     {

--- a/packages/database/src/block-cache.ts
+++ b/packages/database/src/block-cache.ts
@@ -32,6 +32,7 @@ export class BlockCache {
   currentBlockNumber = 0
 
   blockHeaderSubscription: any
+
   BLOCK_CONFIRMATIONS = +(
     process.env.BLOCK_CONFIRMATIONS || DEFAULT_BLOCK_CONFIRMATIONS
   )

--- a/packages/database/src/block-cache.ts
+++ b/packages/database/src/block-cache.ts
@@ -1,0 +1,134 @@
+import Web3 from 'web3'
+import { DB, UpsertOptions, UpdateOptions } from './types'
+
+// process block in memory, write to DB when confirmed by enough blocks
+
+const BLOCK_CONFIRMATIONS = 15
+
+enum OperationType {
+  UPSERT,
+  CREATE,
+  UPDATE,
+}
+
+type PendingDocument = {
+  createdAtBlock: number
+  collection: string
+  operation: OperationType
+  where?: any
+  create?: any
+  update?: any
+}
+
+export class BlockCache {
+  web3: Web3
+
+  db: DB
+
+  pendingDocs = [] as PendingDocument[]
+
+  currentBlockNumber = 0
+
+  blockHeaderSubscription: any
+
+  constructor(web3: Web3, db: DB) {
+    this.web3 = web3
+    this.db = db
+    this.blockHeaderSubscription = this.web3.eth
+      .subscribe('newBlockHeaders', err => {
+        if (err) {
+          console.log('Error subscribing to block headers')
+          console.log(err)
+        }
+      })
+      .on('data', async blockHeader => {
+        this.currentBlockNumber = blockHeader.number
+        // write stuff if needed
+        try {
+          await this.writeChangesIfNeeded()
+        } catch (err) {
+          console.log('Error writing block cache changes')
+          console.log(err)
+        }
+      })
+  }
+
+  async blockNumber() {
+    if (this.currentBlockNumber === 0) {
+      // async load it
+      this.currentBlockNumber = await this.web3.eth.getBlockNumber()
+    }
+    return this.currentBlockNumber
+  }
+
+  // Write any data that is old enough to be considered confirmed
+  async writeChangesIfNeeded() {
+    for (const doc of this.pendingDocs) {
+      if (this.currentBlockNumber - doc.createdAtBlock <= BLOCK_CONFIRMATIONS) {
+        // eslint-disable-next-line no-continue
+        continue
+      }
+      // otherwise write
+      if (doc.operation === OperationType.CREATE) {
+        await this.db.create(doc.collection, doc.create)
+      } else if (doc.operation === OperationType.UPSERT) {
+        await this.db.upsert(doc.collection, {
+          where: doc.where,
+          create: doc.create,
+          update: doc.update,
+        })
+      } else if (doc.operation === OperationType.UPDATE) {
+        await this.db.update(doc.collection, {
+          where: doc.where,
+          update: doc.update,
+        })
+      } else {
+        throw new Error(`Unrecognized operation type: "${doc.operation}"`)
+      }
+    }
+  }
+
+  async upsertCache(
+    blockNumber: number,
+    collection: string,
+    options: UpsertOptions,
+  ) {
+    if (typeof blockNumber !== 'number')
+      throw new Error('Invalid block number provided to BlockCache.upsertCache')
+    const currentBlockNumber = await this.blockNumber()
+    if (currentBlockNumber - blockNumber <= BLOCK_CONFIRMATIONS) {
+      // store in memory
+      this.pendingDocs.push({
+        createdAtBlock: blockNumber,
+        collection,
+        operation: OperationType.UPSERT,
+        ...options,
+      })
+      return
+    }
+    // otherwise create as usual
+    await this.db.upsert(collection, options)
+  }
+
+  async updateCache(
+    blockNumber: number,
+    collection: string,
+    options: UpdateOptions,
+  ) {
+    if (typeof blockNumber !== 'number')
+      throw new Error('Invalid block number provided to BlockCache.upsertCache')
+    const currentBlockNumber = await this.blockNumber()
+    if (currentBlockNumber - blockNumber <= BLOCK_CONFIRMATIONS) {
+      // store in memory
+      this.pendingDocs.push({
+        createdAtBlock: blockNumber,
+        collection,
+        operation: OperationType.UPDATE,
+        ...options,
+      })
+      return
+    }
+    // otherwise operate as usual
+    await this.db.update(collection, options)
+  }
+}

--- a/packages/database/src/connectors/indexed-db.ts
+++ b/packages/database/src/connectors/indexed-db.ts
@@ -12,9 +12,10 @@ import {
   TableData,
   TransactionDB,
   Schema,
-  Relation,
   constructSchema,
 } from '../types'
+import { validateDocuments, matchDocument } from '../helpers/memory'
+import { loadIncluded } from '../helpers/shared'
 
 const DB_NAME = 'zkopru'
 
@@ -93,69 +94,7 @@ export class IndexedDBConnector extends DB {
   ) {
     const table = this.schema[collection]
     if (!table) throw new Error(`Invalid collection: "${collection}"`)
-    const docs = [_doc].flat().map(doc => {
-      // insert defaults where needed
-      const defaults = {}
-      for (const key of Object.keys(table.rowsByName)) {
-        const row = table.rowsByName[key]
-        if (!row) throw new Error('Expected row to exist')
-        if (
-          row.default &&
-          (doc[row.name] === undefined || doc[row.name] === null)
-        ) {
-          Object.assign(defaults, {
-            [row.name]:
-              typeof row.default === 'function' ? row.default() : row.default,
-          })
-        }
-        const wipDoc = {
-          ...defaults,
-          ...doc,
-        }
-        if (
-          !row.optional &&
-          !row.relation &&
-          (wipDoc[row.name] === undefined || wipDoc[row.name] === null)
-        ) {
-          throw new Error(`NULL received for non-optional field "${row.name}"`)
-        }
-        if (
-          typeof wipDoc[row.name] !== 'undefined' &&
-          wipDoc[row.name] !== null
-        ) {
-          if (row.type === 'Bool' && typeof wipDoc[row.name] !== 'boolean') {
-            throw new Error(
-              `Unrecognized value ${wipDoc[row.name]} for type Bool`,
-            )
-          } else if (
-            row.type === 'Int' &&
-            typeof wipDoc[row.name] !== 'number'
-          ) {
-            throw new Error(
-              `Unrecognized value ${wipDoc[row.name]} for type Int`,
-            )
-          } else if (
-            row.type === 'String' &&
-            typeof wipDoc[row.name] !== 'string'
-          ) {
-            throw new Error(
-              `Unrecognized value ${wipDoc[row.name]} for type String`,
-            )
-          } else if (
-            row.type === 'Object' &&
-            typeof wipDoc[row.name] !== 'object'
-          ) {
-            throw new Error(
-              `Unrecognized value ${wipDoc[row.name]} for type Object`,
-            )
-          }
-        }
-      }
-      return {
-        ...defaults,
-        ...doc,
-      }
-    })
+    const docs = validateDocuments(table, _doc)
     if (!this.db) throw new Error('DB is not initialized')
     const tx = _tx || this.db.transaction(collection, 'readwrite')
     const createPromises = docs.map(doc => {
@@ -174,57 +113,6 @@ export class IndexedDBConnector extends DB {
       limit: 1,
     })
     return obj === undefined ? null : obj
-  }
-
-  async loadIncluded(
-    collection: string,
-    options: { models: any[]; include?: any },
-  ) {
-    const { models, include } = options
-    if (!include) return
-    const table = this.schema[collection]
-    if (!table) throw new Error(`Unable to find table ${collection} in schema`)
-    for (const key of Object.keys(include)) {
-      const relation = table.relations[key]
-      if (!relation) {
-        throw new Error(`Unable to find relation ${key} in ${collection}`)
-      }
-      if (include[key]) {
-        await this.loadIncludedModels(
-          models,
-          relation,
-          typeof include[key] === 'object' ? include[key] : undefined,
-        )
-      }
-    }
-  }
-
-  private async loadIncludedModels(
-    models: any[],
-    relation: Relation & { name: string },
-    include?: any,
-  ) {
-    const values = models.map(model => model[relation.localField])
-    // load relevant submodels
-    const submodels = await this._findMany(relation.foreignTable, {
-      where: {
-        [relation.foreignField]: values,
-      },
-      include: include as any, // load subrelations if needed
-    })
-    // key the submodels by their relation field
-    const keyedSubmodels = {}
-    for (const submodel of submodels) {
-      // assign to the models
-      keyedSubmodels[submodel[relation.foreignField]] = submodel
-    }
-    // Assign submodel onto model
-    for (const model of models) {
-      const submodel = keyedSubmodels[model[relation.localField]]
-      Object.assign(model, {
-        [relation.name]: submodel || null,
-      })
-    }
   }
 
   async findMany(collection: string, options: FindManyOptions) {
@@ -299,9 +187,11 @@ export class IndexedDBConnector extends DB {
       const query = index.keys.map(k => options.where[k])
       const result = await txIndex.getAll(query)
       const found = result.filter(i => !!i)
-      await this.loadIncluded(collection, {
+      await loadIncluded(collection, {
         models: found,
         include: options.include,
+        findMany: this._findMany.bind(this),
+        table,
       })
       return found
     }
@@ -339,70 +229,20 @@ export class IndexedDBConnector extends DB {
     } else {
       cursor = await tx.objectStore(collection).openCursor()
     }
-    const matchDoc = (where: WhereClause, doc: any) => {
-      for (const [key, val] of Object.entries(where)) {
-        if (typeof val === 'object' && !Array.isArray(val) && val !== null) {
-          if (typeof val.ne !== 'undefined' && doc[key] === val.ne) {
-            return false
-          }
-          if (typeof val.lt !== 'undefined' && doc[key] >= val.lt) {
-            return false
-          }
-          if (typeof val.lte !== 'undefined' && doc[key] > val.lte) {
-            return false
-          }
-          if (typeof val.gt !== 'undefined' && doc[key] <= val.gt) {
-            return false
-          }
-          if (typeof val.gte !== 'undefined' && doc[key] < val.gte) {
-            return false
-          }
-        } else if (Array.isArray(val)) {
-          let exists = false
-          for (const v of val) {
-            if (v === null && typeof doc[key] === 'undefined') {
-              exists = true
-              break
-            }
-            if (doc[key] === v) {
-              exists = true
-              break
-            }
-          }
-          if (!exists) return false
-        } else if (
-          val === null &&
-          typeof doc[key] !== 'undefined' &&
-          doc[key] !== null
-        ) {
-          return false
-        } else if (val !== null && doc[key] !== val) {
-          return false
-        }
-      }
-      return true
-    }
     const { where, limit } = options
     while (cursor) {
       if (typeof limit === 'number' && found.length >= limit) break
       const obj = cursor.value
-      const topWhere = { ...where, OR: undefined }
-      const or = where.OR || []
-      const matched = matchDoc(topWhere, obj)
-      if (or.length === 0 && matched) {
+      if (matchDocument(where, obj)) {
         found.push(obj)
-      }
-      for (const _where of or) {
-        if (matchDoc(_where, obj) && matched) {
-          found.push(obj)
-          break
-        }
       }
       cursor = await cursor.continue()
     }
-    await this.loadIncluded(collection, {
+    await loadIncluded(collection, {
       models: found,
       include: options.include,
+      findMany: this._findMany.bind(this),
+      table,
     })
     return found
   }

--- a/packages/database/src/connectors/sqlite-memory.ts
+++ b/packages/database/src/connectors/sqlite-memory.ts
@@ -13,7 +13,6 @@ import {
   // normalizeRowDef,
   constructSchema,
   Schema,
-  Relation,
   TransactionDB,
 } from '../types'
 import {
@@ -25,6 +24,7 @@ import {
   deleteManySql,
   upsertSql,
 } from '../helpers/sql'
+import { loadIncluded } from '../helpers/shared'
 
 export class SQLiteMemoryConnector extends DB {
   db: any
@@ -88,59 +88,6 @@ export class SQLiteMemoryConnector extends DB {
     return obj === undefined ? null : obj
   }
 
-  // load related models
-  async loadIncluded(
-    collection: string,
-    options: { models: any[]; include?: any },
-  ) {
-    const { models, include } = options
-    if (!include) return
-    const table = this.schema[collection]
-    if (!table) throw new Error(`Unable to find table ${collection} in schema`)
-    for (const key of Object.keys(include)) {
-      // for each relation to include
-      const relation = table.relations[key]
-      if (!relation)
-        throw new Error(`Unable to find relation ${key} in ${collection}`)
-      if (include[key]) {
-        await this.loadIncludedModels(
-          models,
-          relation,
-          typeof include[key] === 'object' ? include[key] : undefined,
-        )
-      }
-    }
-  }
-
-  // load and assign submodels, mutates the models array supplied
-  private async loadIncludedModels(
-    models: any[],
-    relation: Relation & { name: string },
-    include?: any,
-  ) {
-    const values = models.map(model => model[relation.localField])
-    // load relevant submodels
-    const submodels = await this._findMany(relation.foreignTable, {
-      where: {
-        [relation.foreignField]: values,
-      },
-      include: include as any, // load subrelations if needed
-    })
-    // key the submodels by their relation field
-    const keyedSubmodels = {}
-    for (const submodel of submodels) {
-      // assign to the models
-      keyedSubmodels[submodel[relation.foreignField]] = submodel
-    }
-    // Assign submodel onto model
-    for (const model of models) {
-      const submodel = keyedSubmodels[model[relation.localField]]
-      Object.assign(model, {
-        [relation.name]: submodel || null,
-      })
-    }
-  }
-
   async findMany(collection: string, options: FindManyOptions) {
     return this.lock.acquire('read', async () =>
       this._findMany(collection, options),
@@ -180,9 +127,11 @@ export class SQLiteMemoryConnector extends DB {
       }
     }
     const { include } = options
-    await this.loadIncluded(collection, {
+    await loadIncluded(collection, {
       models,
       include,
+      findMany: this._findMany.bind(this),
+      table,
     })
     return models
   }

--- a/packages/database/src/connectors/sqlite.ts
+++ b/packages/database/src/connectors/sqlite.ts
@@ -14,7 +14,6 @@ import {
   // normalizeRowDef,
   constructSchema,
   Schema,
-  Relation,
   TransactionDB,
 } from '../types'
 import {
@@ -26,6 +25,7 @@ import {
   deleteManySql,
   upsertSql,
 } from '../helpers/sql'
+import { loadIncluded } from '../helpers/shared'
 
 export class SQLiteConnector extends DB {
   db: any // Database<sqlite3.Database, sqlite3.Statement>
@@ -104,59 +104,6 @@ export class SQLiteConnector extends DB {
     return obj === undefined ? null : obj
   }
 
-  // load related models
-  async loadIncluded(
-    collection: string,
-    options: { models: any[]; include?: any },
-  ) {
-    const { models, include } = options
-    if (!include) return
-    const table = this.schema[collection]
-    if (!table) throw new Error(`Unable to find table ${collection} in schema`)
-    for (const key of Object.keys(include)) {
-      // for each relation to include
-      const relation = table.relations[key]
-      if (!relation)
-        throw new Error(`Unable to find relation ${key} in ${collection}`)
-      if (include[key]) {
-        await this.loadIncludedModels(
-          models,
-          relation,
-          typeof include[key] === 'object' ? include[key] : undefined,
-        )
-      }
-    }
-  }
-
-  // load and assign submodels, mutates the models array supplied
-  private async loadIncludedModels(
-    models: any[],
-    relation: Relation & { name: string },
-    include?: any,
-  ) {
-    const values = models.map(model => model[relation.localField])
-    // load relevant submodels
-    const submodels = await this._findMany(relation.foreignTable, {
-      where: {
-        [relation.foreignField]: values,
-      },
-      include: include as any, // load subrelations if needed
-    })
-    // key the submodels by their relation field
-    const keyedSubmodels = {}
-    for (const submodel of submodels) {
-      // assign to the models
-      keyedSubmodels[submodel[relation.foreignField]] = submodel
-    }
-    // Assign submodel onto model
-    for (const model of models) {
-      const submodel = keyedSubmodels[model[relation.localField]]
-      Object.assign(model, {
-        [relation.name]: submodel || null,
-      })
-    }
-  }
-
   async findMany(collection: string, options: FindManyOptions) {
     return this.lock.acquire('read', async () =>
       this._findMany(collection, options),
@@ -186,9 +133,11 @@ export class SQLiteConnector extends DB {
       }
     }
     const { include } = options
-    await this.loadIncluded(collection, {
+    await loadIncluded(collection, {
       models,
       include,
+      findMany: this._findMany.bind(this),
+      table,
     })
     return models
   }

--- a/packages/database/src/helpers/memory.ts
+++ b/packages/database/src/helpers/memory.ts
@@ -1,0 +1,125 @@
+/* eslint-disable no-underscore-dangle */
+import { SchemaTable, WhereClause } from '../types'
+
+// Validate documents, insert defaults, ensure non-optional fields are present
+export function validateDocuments(table: SchemaTable, _docs: any | any[]) {
+  return [_docs].flat().map(doc => {
+    // insert defaults where needed
+    const defaults = {}
+    for (const key of Object.keys(table.rowsByName)) {
+      const row = table.rowsByName[key]
+      if (!row) throw new Error('Expected row to exist')
+      if (
+        row.default &&
+        (doc[row.name] === undefined || doc[row.name] === null)
+      ) {
+        Object.assign(defaults, {
+          [row.name]:
+            typeof row.default === 'function' ? row.default() : row.default,
+        })
+      }
+      const wipDoc = {
+        ...defaults,
+        ...doc,
+      }
+      if (
+        !row.optional &&
+        !row.relation &&
+        (wipDoc[row.name] === undefined || wipDoc[row.name] === null)
+      ) {
+        throw new Error(`NULL received for non-optional field "${row.name}"`)
+      }
+      if (
+        typeof wipDoc[row.name] !== 'undefined' &&
+        wipDoc[row.name] !== null
+      ) {
+        if (row.type === 'Bool' && typeof wipDoc[row.name] !== 'boolean') {
+          throw new Error(
+            `Unrecognized value ${wipDoc[row.name]} for type Bool`,
+          )
+        } else if (row.type === 'Int' && typeof wipDoc[row.name] !== 'number') {
+          throw new Error(`Unrecognized value ${wipDoc[row.name]} for type Int`)
+        } else if (
+          row.type === 'String' &&
+          typeof wipDoc[row.name] !== 'string'
+        ) {
+          throw new Error(
+            `Unrecognized value ${wipDoc[row.name]} for type String`,
+          )
+        } else if (
+          row.type === 'Object' &&
+          typeof wipDoc[row.name] !== 'object'
+        ) {
+          throw new Error(
+            `Unrecognized value ${wipDoc[row.name]} for type Object`,
+          )
+        }
+      }
+    }
+    return {
+      ...defaults,
+      ...doc,
+    }
+  }) as any[]
+}
+
+// Matches without considering OR clauses
+function _matchDocument(where: WhereClause, doc: any) {
+  for (const [key, val] of Object.entries(where)) {
+    if (typeof val === 'object' && !Array.isArray(val) && val !== null) {
+      if (typeof val.ne !== 'undefined' && doc[key] === val.ne) {
+        return false
+      }
+      if (typeof val.lt !== 'undefined' && doc[key] >= val.lt) {
+        return false
+      }
+      if (typeof val.lte !== 'undefined' && doc[key] > val.lte) {
+        return false
+      }
+      if (typeof val.gt !== 'undefined' && doc[key] <= val.gt) {
+        return false
+      }
+      if (typeof val.gte !== 'undefined' && doc[key] < val.gte) {
+        return false
+      }
+    } else if (Array.isArray(val)) {
+      let exists = false
+      for (const v of val) {
+        if (v === null && typeof doc[key] === 'undefined') {
+          exists = true
+          break
+        }
+        if (doc[key] === v) {
+          exists = true
+          break
+        }
+      }
+      if (!exists) return false
+    } else if (
+      val === null &&
+      typeof doc[key] !== 'undefined' &&
+      doc[key] !== null
+    ) {
+      return false
+    } else if (val !== null && doc[key] !== val) {
+      return false
+    }
+  }
+  return true
+}
+
+// Match a document in memory
+export function matchDocument(where: WhereClause, doc: any) {
+  const topWhere = { ...where, OR: undefined }
+  const or = where.OR || []
+  const matched = _matchDocument(topWhere, doc)
+  if (or.length === 0 && matched) {
+    return true
+  }
+  for (const _where of or) {
+    if (_matchDocument(_where, doc) && matched) {
+      return true
+    }
+  }
+  return false
+}

--- a/packages/database/src/helpers/memory.ts
+++ b/packages/database/src/helpers/memory.ts
@@ -82,6 +82,13 @@ function _matchDocument(where: WhereClause, doc: any) {
       if (typeof val.gte !== 'undefined' && doc[key] < val.gte) {
         return false
       }
+      if (typeof val.nin !== 'undefined') {
+        if (!Array.isArray(val.nin))
+          throw new Error('Invalid nin value provided, must be array')
+        for (const v of val.nin) {
+          if (doc[key] === v) return false
+        }
+      }
     } else if (Array.isArray(val)) {
       let exists = false
       for (const v of val) {

--- a/packages/database/src/helpers/memory.ts
+++ b/packages/database/src/helpers/memory.ts
@@ -120,12 +120,12 @@ export function matchDocument(where: WhereClause, doc: any) {
   }
   for (const _where of and) {
     // All AND clauses must be met
-    if (!_matchDocument(_where, doc)) return false
+    if (!matchDocument(_where, doc)) return false
   }
   if (or.length === 0) return true
   for (const _where of or) {
     // only 1 OR clause must be matched
-    if (_matchDocument(_where, doc) && matched) {
+    if (matchDocument(_where, doc) && matched) {
       return true
     }
   }

--- a/packages/database/src/helpers/memory.ts
+++ b/packages/database/src/helpers/memory.ts
@@ -110,13 +110,21 @@ function _matchDocument(where: WhereClause, doc: any) {
 
 // Match a document in memory
 export function matchDocument(where: WhereClause, doc: any) {
-  const topWhere = { ...where, OR: undefined }
+  const topWhere = { ...where, OR: undefined, AND: undefined }
   const or = where.OR || []
+  const and = where.AND || []
   const matched = _matchDocument(topWhere, doc)
-  if (or.length === 0 && matched) {
+  if (!matched) return false
+  if (or.length === 0 && and.length === 0 && matched) {
     return true
   }
+  for (const _where of and) {
+    // All AND clauses must be met
+    if (!_matchDocument(_where, doc)) return false
+  }
+  if (or.length === 0) return true
   for (const _where of or) {
+    // only 1 OR clause must be matched
     if (_matchDocument(_where, doc) && matched) {
       return true
     }

--- a/packages/database/src/helpers/shared.ts
+++ b/packages/database/src/helpers/shared.ts
@@ -1,33 +1,5 @@
 import { SchemaTable, Relation } from '../types'
 
-export async function loadIncluded(
-  collection: string,
-  options: {
-    models: any[];
-    include?: any;
-    findMany: Function;
-    table: SchemaTable
-   },
-) {
-  const { models, include, table, findMany } = options
-  if (!include) return
-  if (!table) throw new Error(`Unable to find table ${collection} in schema`)
-  for (const key of Object.keys(include)) {
-    const relation = table.relations[key]
-    if (!relation) {
-      throw new Error(`Unable to find relation ${key} in ${collection}`)
-    }
-    if (include[key]) {
-      await loadIncludedModels(
-        models,
-        relation,
-        findMany,
-        typeof include[key] === 'object' ? include[key] : undefined,
-      )
-    }
-  }
-}
-
 async function loadIncludedModels(
   models: any[],
   relation: Relation & { name: string },
@@ -54,5 +26,33 @@ async function loadIncludedModels(
     Object.assign(model, {
       [relation.name]: submodel || null,
     })
+  }
+}
+
+export async function loadIncluded(
+  collection: string,
+  options: {
+    models: any[]
+    include?: any
+    findMany: Function
+    table: SchemaTable
+  },
+) {
+  const { models, include, table, findMany } = options
+  if (!include) return
+  if (!table) throw new Error(`Unable to find table ${collection} in schema`)
+  for (const key of Object.keys(include)) {
+    const relation = table.relations[key]
+    if (!relation) {
+      throw new Error(`Unable to find relation ${key} in ${collection}`)
+    }
+    if (include[key]) {
+      await loadIncludedModels(
+        models,
+        relation,
+        findMany,
+        typeof include[key] === 'object' ? include[key] : undefined,
+      )
+    }
   }
 }

--- a/packages/database/src/helpers/shared.ts
+++ b/packages/database/src/helpers/shared.ts
@@ -1,0 +1,58 @@
+import { SchemaTable, Relation } from '../types'
+
+export async function loadIncluded(
+  collection: string,
+  options: {
+    models: any[];
+    include?: any;
+    findMany: Function;
+    table: SchemaTable
+   },
+) {
+  const { models, include, table, findMany } = options
+  if (!include) return
+  if (!table) throw new Error(`Unable to find table ${collection} in schema`)
+  for (const key of Object.keys(include)) {
+    const relation = table.relations[key]
+    if (!relation) {
+      throw new Error(`Unable to find relation ${key} in ${collection}`)
+    }
+    if (include[key]) {
+      await loadIncludedModels(
+        models,
+        relation,
+        findMany,
+        typeof include[key] === 'object' ? include[key] : undefined,
+      )
+    }
+  }
+}
+
+async function loadIncludedModels(
+  models: any[],
+  relation: Relation & { name: string },
+  findMany: Function,
+  include?: any,
+) {
+  const values = models.map(model => model[relation.localField])
+  // load relevant submodels
+  const submodels = await findMany(relation.foreignTable, {
+    where: {
+      [relation.foreignField]: values,
+    },
+    include: include as any, // load subrelations if needed
+  })
+  // key the submodels by their relation field
+  const keyedSubmodels = {}
+  for (const submodel of submodels) {
+    // assign to the models
+    keyedSubmodels[submodel[relation.foreignField]] = submodel
+  }
+  // Assign submodel onto model
+  for (const model of models) {
+    const submodel = keyedSubmodels[model[relation.localField]]
+    Object.assign(model, {
+      [relation.name]: submodel || null,
+    })
+  }
+}

--- a/packages/database/src/helpers/sql.ts
+++ b/packages/database/src/helpers/sql.ts
@@ -37,7 +37,7 @@ export function whereToSql(table: SchemaTable, doc: any = {}, sqlOnly = false) {
   if (Object.keys(doc).length === 0) return ''
   const sql = Object.keys(doc)
     .map(key => {
-      if (key === 'OR') return
+      if (key === 'OR' || key === 'AND') return
       const rowDef = table.rowsByName[key]
       if (!rowDef)
         throw new Error(`Unable to find row definition for key: "${key}"`)
@@ -78,14 +78,22 @@ export function whereToSql(table: SchemaTable, doc: any = {}, sqlOnly = false) {
     .flat()
     .filter(i => !!i)
     .join(' AND ')
-  if (Array.isArray(doc.OR)) {
-    const orConditions = doc.OR.map((w: any) =>
-      whereToSql(table, w, true),
-    ).join(' OR ')
-    return ` ${sqlOnly ? '' : 'WHERE'}
-    (${sql || 'true'}) AND (${orConditions})`
-  }
-  return ` ${sqlOnly ? '' : 'WHERE'} ${sql} `
+  const orConditions = Array.isArray(doc.OR)
+    ? doc.OR.map((w: any) => whereToSql(table, w, true)).join(' OR ')
+    : 'true'
+  const andConditions = Array.isArray(doc.AND)
+    ? doc.AND.map((w: any) => whereToSql(table, w, true)).join(' AND ')
+    : 'true'
+  return ` ${sqlOnly ? '' : 'WHERE'} (${sql ||
+    'true'}) AND (${orConditions}) AND (${andConditions})`
+  // if (Array.isArray(doc.OR)) {
+  //   const orConditions = doc.OR.map((w: any) =>
+  //     whereToSql(table, w, true),
+  //   ).join(' OR ')
+  //   return ` ${sqlOnly ? '' : 'WHERE'}
+  //   (${sql || 'true'}) AND (${orConditions})`
+  // }
+  // return ` ${sqlOnly ? '' : 'WHERE'} ${sql} `
 }
 
 export function tableCreationSql(tableData: TableData[]) {

--- a/packages/database/src/helpers/sql.ts
+++ b/packages/database/src/helpers/sql.ts
@@ -66,6 +66,13 @@ export function whereToSql(table: SchemaTable, doc: any = {}, sqlOnly = false) {
           eq: 'IS',
         }
         return Object.keys(val).map(k => {
+          if (k === 'nin') {
+            if (!Array.isArray(val[k]))
+              throw new Error(`Non array value provided for nin operator`)
+            // need to generate a NOT IN query
+            const values = val[k].map((v: any) => parseType(rowDef.type, v))
+            return `"${key}" NOT IN (${values.join(',')})`
+          }
           const operator = val[k] === null ? nullOperatorMap[k] : operatorMap[k]
           if (!operator) throw new Error(`Invalid operator ${k}`)
           const parsed = parseType(rowDef.type, val[k])

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -41,4 +41,6 @@ export const NULLIFIER_TREE_ID = 'nullifier-tree'
 export * from './types'
 export * from './schema.types'
 export * from './preset'
+export * from './block-cache'
+export * from './helpers/memory'
 export { schema }

--- a/packages/database/tests/database/find.ts
+++ b/packages/database/tests/database/find.ts
@@ -94,6 +94,22 @@ export default function(this: { db: DB }) {
     assert.equal(rows[2].id, 'test4')
   })
 
+  test('should find using nin operator', async () => {
+    const table = 'TableThree'
+    for (let x = 0; x < 10; x++) {
+      await this.db.create(table, {
+        id: `test${x}`,
+        optionalField: 'test',
+      })
+    }
+    const rows = await this.db.findMany(table, {
+      where: {
+        id: { nin: ['test0', 'test1', 'test8', 'test9'] },
+      }
+    })
+    assert.equal(rows.length, 6)
+  })
+
   test('should load nested relations', async () => {
     await this.db.create('TableFour', [
       {

--- a/packages/database/tests/database/find.ts
+++ b/packages/database/tests/database/find.ts
@@ -105,7 +105,7 @@ export default function(this: { db: DB }) {
     const rows = await this.db.findMany(table, {
       where: {
         id: { nin: ['test0', 'test1', 'test8', 'test9'] },
-      }
+      },
     })
     assert.equal(rows.length, 6)
   })
@@ -380,10 +380,10 @@ export default function(this: { db: DB }) {
       const docs = await this.db.findMany(table, {
         where: {
           AND: [
-            { OR: [{ counterField: { lt: 4 }}, { counterField: { gt: 6}}]},
-            { counterField: [1, 5, 8]}
-          ]
-        }
+            { OR: [{ counterField: { lt: 4 } }, { counterField: { gt: 6 } }] },
+            { counterField: [1, 5, 8] },
+          ],
+        },
       })
       assert.equal(docs.length, 2)
     }

--- a/packages/database/tests/database/find.ts
+++ b/packages/database/tests/database/find.ts
@@ -278,4 +278,65 @@ export default function(this: { db: DB }) {
       assert.equal(docs.length, 5)
     }
   })
+
+  test('should use AND logic', async () => {
+    const table = 'TableTwo'
+    for (let x = 0; x < 10; x++) {
+      await this.db.create(table, {
+        counterField: x,
+      })
+      await new Promise(r => setTimeout(r, 10))
+    }
+    {
+      const docs = await this.db.findMany(table, {
+        where: {
+          AND: [{ counterField: 0 }, { counterField: 1} ]
+        }
+      })
+      assert.equal(docs.length, 0)
+    }
+    {
+      const docs = await this.db.findMany(table, {
+        where: {
+          AND: [{ counterField: { gte: 5 } }, { counterField: { ne: 6 }}]
+        }
+      })
+      assert.equal(docs.length, 4)
+    }
+    {
+      const docs = await this.db.findMany(table, {
+        where: {
+          AND: [{ counterField: { lte: 5 } }, { counterField: [ 1, 2, 7, 9 ] }]
+        }
+      })
+      assert.equal(docs.length, 2)
+    }
+    {
+      const docs = await this.db.findMany(table, {
+        where: {
+          AND: [{ counterField: { ne: 5 } }, { counterField: [ 5 ] }]
+        }
+      })
+      assert.equal(docs.length, 0)
+    }
+  })
+
+  test('should use OR and AND logic', async () => {
+    const table = 'TableTwo'
+    for (let x = 0; x < 10; x++) {
+      await this.db.create(table, {
+        counterField: x,
+      })
+      await new Promise(r => setTimeout(r, 10))
+    }
+    {
+      const docs = await this.db.findMany(table, {
+        where: {
+          AND: [{ counterField: { gt: 5 } }, { counterField: [ 7, 8, 9]}],
+          OR: [{ counterField: { gt: 8 }}, { counterField: 7 }]
+        }
+      })
+      assert.equal(docs.length, 2)
+    }
+  })
 }

--- a/packages/database/tests/database/find.ts
+++ b/packages/database/tests/database/find.ts
@@ -290,32 +290,32 @@ export default function(this: { db: DB }) {
     {
       const docs = await this.db.findMany(table, {
         where: {
-          AND: [{ counterField: 0 }, { counterField: 1} ]
-        }
+          AND: [{ counterField: 0 }, { counterField: 1 }],
+        },
       })
       assert.equal(docs.length, 0)
     }
     {
       const docs = await this.db.findMany(table, {
         where: {
-          AND: [{ counterField: { gte: 5 } }, { counterField: { ne: 6 }}]
-        }
+          AND: [{ counterField: { gte: 5 } }, { counterField: { ne: 6 } }],
+        },
       })
       assert.equal(docs.length, 4)
     }
     {
       const docs = await this.db.findMany(table, {
         where: {
-          AND: [{ counterField: { lte: 5 } }, { counterField: [ 1, 2, 7, 9 ] }]
-        }
+          AND: [{ counterField: { lte: 5 } }, { counterField: [1, 2, 7, 9] }],
+        },
       })
       assert.equal(docs.length, 2)
     }
     {
       const docs = await this.db.findMany(table, {
         where: {
-          AND: [{ counterField: { ne: 5 } }, { counterField: [ 5 ] }]
-        }
+          AND: [{ counterField: { ne: 5 } }, { counterField: [5] }],
+        },
       })
       assert.equal(docs.length, 0)
     }
@@ -332,8 +332,41 @@ export default function(this: { db: DB }) {
     {
       const docs = await this.db.findMany(table, {
         where: {
-          AND: [{ counterField: { gt: 5 } }, { counterField: [ 7, 8, 9]}],
-          OR: [{ counterField: { gt: 8 }}, { counterField: 7 }]
+          AND: [{ counterField: { gt: 5 } }, { counterField: [7, 8, 9] }],
+          OR: [{ counterField: { gt: 8 } }, { counterField: 7 }],
+        },
+      })
+      assert.equal(docs.length, 2)
+    }
+  })
+
+  test('should use nested OR and AND logic', async () => {
+    const table = 'TableTwo'
+    for (let x = 0; x < 10; x++) {
+      await this.db.create(table, {
+        counterField: x,
+      })
+    }
+    {
+      const docs = await this.db.findMany(table, {
+        where: {
+          AND: [
+            { AND: [{ counterField: { gt: 2 } }, { counterField: { lt: 8 } }] },
+            {
+              counterField: [1, 4, 6, 9],
+            },
+          ],
+        },
+      })
+      assert.equal(docs.length, 2)
+    }
+    {
+      const docs = await this.db.findMany(table, {
+        where: {
+          AND: [
+            { OR: [{ counterField: { lt: 4 }}, { counterField: { gt: 6}}]},
+            { counterField: [1, 5, 8]}
+          ]
         }
       })
       assert.equal(docs.length, 2)

--- a/packages/integration-test/tests/index.test.ts
+++ b/packages/integration-test/tests/index.test.ts
@@ -29,7 +29,11 @@ import {
   depositERC721,
   testMassDeposits,
 } from './cases/4_deposit'
-import { jestExtendToCompareBigNumber, sleep } from '~utils'
+import {
+  jestExtendToCompareBigNumber,
+  sleep,
+  attachConsoleLogToPino,
+} from '~utils'
 import { attachConsoleErrorToPino } from '~utils/logger'
 import {
   waitCoordinatorToProposeANewBlock,
@@ -66,7 +70,6 @@ import {
   testRound3SendZkTxsToCoordinator,
   testRound3NewBlockProposalAndSlashing,
 } from './cases/9_zk_tx_round_3'
-import { attachConsoleLogToPino } from '~utils'
 
 process.env.DEFAULT_COORDINATOR = 'http://localhost:8888'
 process.env.BLOCK_CONFIRMATIONS = '0'

--- a/packages/integration-test/tests/index.test.ts
+++ b/packages/integration-test/tests/index.test.ts
@@ -66,9 +66,10 @@ import {
   testRound3SendZkTxsToCoordinator,
   testRound3NewBlockProposalAndSlashing,
 } from './cases/9_zk_tx_round_3'
-// import { attachConsoleLogToPino } from '~utils'
+import { attachConsoleLogToPino } from '~utils'
 
 process.env.DEFAULT_COORDINATOR = 'http://localhost:8888'
+process.env.BLOCK_CONFIRMATIONS = '0'
 
 jestExtendToCompareBigNumber(expect)
 
@@ -77,6 +78,7 @@ describe('testnet', () => {
   let context!: Context
   const ctx = () => context
   beforeAll(async () => {
+    if (process.env.DEBUG) attachConsoleLogToPino()
     attachConsoleErrorToPino()
     context = await initContext()
   }, 90000)


### PR DESCRIPTION
A more simple implementation to replace #233 

This implementation quarantines proposals, deposits, finalization, and anything else that happens on chain in an in-memory cache. During this quarantine time (15-30 blocks) the data is not written to the DB. The cache can expose some information about the quarantined data (e.g. pending balances, deposits, withdrawals, etc.). Once sufficient time passes the data is written to disk automatically.

This is a more simple approach. It does not allow the user to optimistically interact with funds but is more likely to work well.

Coordinators can run a node with a lower `BLOCK_CONFIRMATIONS` value to reduce the time before a block is generated (to avoid wasting the rounds they own). It might make sense to allow the user to adjust this value in the wallet (advanced settings tab maybe)? 12 blocks seems to be a safe value used by others.