### PR TITLE
TX history refactor/hexify fixes/tree fixes

### DIFF
--- a/packages/account/src/account.ts
+++ b/packages/account/src/account.ts
@@ -9,23 +9,25 @@ import {
   verifyEdDSA,
 } from '@zkopru/babyjubjub'
 import { Keystore } from '@zkopru/database'
-import { hexify } from '@zkopru/utils'
 import createKeccak from 'keccak'
 import assert from 'assert'
 import { ZkViewer } from './viewer'
 
 export class ZkAccount extends ZkViewer {
-  private privateKey: Buffer | string // ECDSA private key
+  private privateKey: string // ECDSA private key
 
   ethAddress: string
 
   ethAccount: Account
 
-  constructor(privateKey: Buffer | string) {
+  constructor(_privateKey: Buffer | string) {
     const web3 = new Web3()
-    const ethAccount = web3.eth.accounts.privateKeyToAccount(
-      hexify(privateKey, 32),
-    )
+    const privateKey =
+      typeof _privateKey === 'string'
+        ? _privateKey
+        : _privateKey.toString('hex')
+
+    const ethAccount = web3.eth.accounts.privateKeyToAccount(privateKey)
 
     const A = Point.fromPrivKey(privateKey)
     // https://github.com/zkopru-network/zkopru/issues/34#issuecomment-666988505
@@ -64,7 +66,7 @@ export class ZkAccount extends ZkViewer {
   toAddAccount(): AddAccount {
     return {
       address: this.ethAddress,
-      privateKey: hexify(this.privateKey, 32),
+      privateKey: this.privateKey,
     }
   }
 

--- a/packages/account/tests/account.test.ts
+++ b/packages/account/tests/account.test.ts
@@ -9,7 +9,10 @@ describe('class ZkAccount', () => {
       Buffer.from("I am Alice's private key"),
       64,
     )
-    const bobPrivKey = trimHexToLength(Buffer.from("I am Bob's private key"), 64)
+    const bobPrivKey = trimHexToLength(
+      Buffer.from("I am Bob's private key"),
+      64,
+    )
     const alice = new ZkAccount(alicePrivKey)
     const bob = new ZkAccount(bobPrivKey)
     const msg = Fp.from('0xabcd12344321d')

--- a/packages/account/tests/account.test.ts
+++ b/packages/account/tests/account.test.ts
@@ -1,12 +1,15 @@
 /* eslint-disable jest/no-hooks */
 import { Fp, verifyEdDSA } from '@zkopru/babyjubjub'
-import { hexify } from '~utils'
 import { ZkAccount } from '~account'
+import { trimHexToLength } from '~utils'
 
 describe('class ZkAccount', () => {
   it('should make eddsa signature and verify that', async () => {
-    const alicePrivKey = hexify("I am Alice's private key")
-    const bobPrivKey = hexify("I am Bob's private key")
+    const alicePrivKey = trimHexToLength(
+      Buffer.from("I am Alice's private key"),
+      64,
+    )
+    const bobPrivKey = trimHexToLength(Buffer.from("I am Bob's private key"), 64)
     const alice = new ZkAccount(alicePrivKey)
     const bob = new ZkAccount(bobPrivKey)
     const msg = Fp.from('0xabcd12344321d')

--- a/packages/babyjubjub/src/point.ts
+++ b/packages/babyjubjub/src/point.ts
@@ -1,4 +1,4 @@
-import { hexToBuffer, hexify } from '@zkopru/utils'
+import { hexToBuffer } from '@zkopru/utils'
 import * as ffjs from 'ffjavascript'
 import * as circomlib from 'circomlib'
 import createBlakeHash from 'blake-hash'
@@ -106,7 +106,9 @@ export class Point {
   }
 
   toHex(): string {
-    return hexify(this.encode(), 32)
+    const encoded = this.encode()
+    if (encoded.length !== 32) throw new Error('Expected 32 bytes')
+    return encoded.toString('hex')
   }
 
   toBigIntArr(): bigint[] {

--- a/packages/client/tests/rpc.test.ts
+++ b/packages/client/tests/rpc.test.ts
@@ -7,13 +7,13 @@ import { FullNode } from '@zkopru/core'
 import Zkopru from '../src'
 import { Coordinator } from '~coordinator'
 import { ZkAccount } from '~account'
-import { sleep } from '~utils'
+import { sleep, trimHexToLength } from '~utils'
 import { readFromContainer, pullOrBuildAndGetContainer } from '~utils-docker'
 import { DB, SQLiteConnector, schema } from '~database-node'
 
 describe('rPC tests', () => {
   const accounts: ZkAccount[] = [
-    new ZkAccount(Buffer.from('sample private key')),
+    new ZkAccount(trimHexToLength(Buffer.from('sample private key'), 64)),
   ]
   let address
   let container: Container

--- a/packages/contracts/test-cases/test/libraries/utxo-tree.soltest.js
+++ b/packages/contracts/test-cases/test/libraries/utxo-tree.soltest.js
@@ -68,7 +68,7 @@ contract("Utxo tree update tests", async accounts => {
       // const { root, index, siblings } = tsTree.data
       // const prevIndex = tsTree.latestLeafIndex()
       const leaves = [Fp.from("1"), Fp.from("2")];
-      const prevTree = tsTree.getStartingLeafProof();
+      const prevTree = await tsTree.getStartingLeafProof();
       const utxoTreeResult = await tsTree.dryAppend(leaves.map(toLeaf));
       // console.log(utxoTreeResult)
       // console.log(siblings)

--- a/packages/coordinator/tests/unit/coordinator.test.ts
+++ b/packages/coordinator/tests/unit/coordinator.test.ts
@@ -10,7 +10,7 @@ import assert from 'assert'
 import fetch from 'node-fetch'
 import { Coordinator } from '~coordinator'
 import { ZkAccount } from '~account'
-import { sleep } from '~utils'
+import { sleep, trimHexToLength } from '~utils'
 import { readFromContainer, pullOrBuildAndGetContainer } from '~utils-docker'
 import { DB, SQLiteConnector, schema } from '~database/node'
 
@@ -58,7 +58,7 @@ async function callMethod(
 
 describe('coordinator test to run testnet', () => {
   const accounts: ZkAccount[] = [
-    new ZkAccount(Buffer.from('sample private key')),
+    new ZkAccount(trimHexToLength(Buffer.from('sample private key'), 64)),
   ]
   let address
   let container: Container

--- a/packages/core/src/node/block-processor.ts
+++ b/packages/core/src/node/block-processor.ts
@@ -316,9 +316,6 @@ export class BlockProcessor extends EventEmitter {
         hash: tx.outflow.map(outflow => outflow.note.toString())
       }
     })
-    if (outflows.length !== tx.outflow.length) {
-      throw new Error('Not all outflows are known')
-    }
     const outflowTokenAddresses = {}
     const outflowOwners = {}
     let nft = false
@@ -338,6 +335,9 @@ export class BlockProcessor extends EventEmitter {
     if (Object.keys(outflowOwners).length > 1) {
       logger.warn('Multiple outflow owners not supported')
       return
+    }
+    if (outflows.length !== tx.outflow.length) {
+      throw new Error('Not all outflows are known')
     }
     const tokenAddress = `0x${decryptedNotes[0].asset.tokenAddr.toString(
       'hex',

--- a/packages/core/src/node/block-processor.ts
+++ b/packages/core/src/node/block-processor.ts
@@ -721,10 +721,10 @@ export class BlockProcessor extends EventEmitter {
       )
       assert(orderInArr >= 0)
       const index = startingWithdrawalIndex.addn(orderInArr)
-      const { noteHash } = patch.treePatch.withdrawals[orderInArr]
-      if (!noteHash) throw Error('Withdrawal does not have note hash')
+      const { hash } = patch.treePatch.withdrawals[orderInArr]
+      if (!hash) throw Error('Withdrawal does not have note hash')
       const merkleProof = await this.layer2.grove.withdrawalMerkleProof(
-        noteHash,
+        hash,
         index,
       )
       withdrawalsToUpdate.push({

--- a/packages/core/src/node/block-processor.ts
+++ b/packages/core/src/node/block-processor.ts
@@ -313,8 +313,8 @@ export class BlockProcessor extends EventEmitter {
   ) {
     const outflows = await this.db.findMany('Utxo', {
       where: {
-        hash: tx.outflow.map(outflow => outflow.note.toString())
-      }
+        hash: tx.outflow.map(outflow => outflow.note.toString()),
+      },
     })
     const outflowTokenAddresses = {}
     const outflowOwners = {}
@@ -367,15 +367,16 @@ export class BlockProcessor extends EventEmitter {
     }
     // otherwise we're the sender
     const totalSent = outflows
-      .filter((outflow) => outflow.owner === knownReceiver.zkAddress)
+      .filter(outflow => outflow.owner === knownReceiver.zkAddress)
       .reduce((total, outflow) => {
         if (+tokenAddress === 0 && tokenAddress === outflow.tokenAddr) {
           return total.add(Fp.from(outflow.erc20Amount))
-        } else {
-          return total.add(Fp.from(outflow.eth))
         }
+        return total.add(Fp.from(outflow.eth))
       }, Fp.from(0))
-    const netSent = totalSent.sub(myInflowTotal).sub(+tokenAddress === 0 ? tx.fee : Fp.from(0))
+    const netSent = totalSent
+      .sub(myInflowTotal)
+      .sub(+tokenAddress === 0 ? tx.fee : Fp.from(0))
     db.update('Tx', {
       where: {
         hash: tx.hash().toString(),

--- a/packages/core/src/node/block-processor.ts
+++ b/packages/core/src/node/block-processor.ts
@@ -397,63 +397,6 @@ export class BlockProcessor extends EventEmitter {
         amount: netSent.toString(),
       },
     })
-    // // if we have decrypted all notes we're the sender and receiver
-    // const knownInflow = await this.db.findMany('Utxo', {
-    //   where: {
-    //     nullifier: tx.inflow.map(inflow => inflow.nullifier.toString()),
-    //   },
-    // })
-    // // let's use the trivial approach of assuming the first asset encountered is
-    // // the only asset being transacted
-    // const myOutflowTotal = decryptedNotes.reduce((total, note: Utxo) => {
-    //   if (+tokenAddress === 0) {
-    //     return total.add(new Fp(note.asset.eth))
-    //   }
-    //   if (note.asset.tokenAddr.eq(Fp.from(tokenAddress))) {
-    //     return total.add(note.asset.erc20Amount)
-    //   }
-    //   return total
-    // }, new Fp('0'))
-    // // if we know a nullifier before the block is processed we must be the
-    // // sender
-    // if (knownInflow.length) {
-    //   if (knownInflow.length !== tx.inflow.length) {
-    //     throw new Error(`Unknown inflow in send transaction`)
-    //   }
-    //   const sentAmount = Fp.from(0)
-    //   for (const inflow of knownInflow) {
-    //     if (+tokenAddress === 0 && inflow.eth) {
-    //       sentAmount.iadd(Fp.from(inflow.eth))
-    //     } else if (Fp.from(inflow.tokenAddr).eq(Fp.from(tokenAddress))) {
-    //       sentAmount.iadd(Fp.from(inflow.erc20Amount))
-    //     }
-    //   }
-    //   // sentAmount = totalInflow - myOutflow - fee
-    //   const totalSent = sentAmount.sub(myOutflowTotal).sub(tx.fee)
-    //   // we're likely the sender
-    //   db.update('Tx', {
-    //     where: {
-    //       hash: tx.hash().toString(),
-    //     },
-    //     update: {
-    //       senderAddress: knownReceiver.zkAddress.toString(),
-    //       tokenAddr: tokenAddress,
-    //       amount: totalSent.toString(),
-    //     },
-    //   })
-    // } else {
-    //   // we're likely the receiver
-    //   db.update('Tx', {
-    //     where: {
-    //       hash: tx.hash().toString(),
-    //     },
-    //     update: {
-    //       receiverAddress: knownReceiver.zkAddress.toString(),
-    //       tokenAddr: tokenAddress,
-    //       amount: myOutflowTotal.toString(),
-    //     },
-    //   })
-    // }
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/packages/core/src/node/block-processor.ts
+++ b/packages/core/src/node/block-processor.ts
@@ -7,6 +7,9 @@ import {
   Proposal,
   MassDeposit as MassDepositSql,
   TransactionDB,
+  clearTreeCache,
+  enableTreeCache,
+  disableTreeCache,
 } from '@zkopru/database'
 import { logger, Worker } from '@zkopru/utils'
 import assert from 'assert'
@@ -212,30 +215,37 @@ export class BlockProcessor extends EventEmitter {
     const tokenRegistry = await this.layer2.getTokenRegistry()
     // generate a patch to current db
     const patch = await this.makePatch(parent, block)
-    await this.db.transaction(async db => {
-      // Progressively apply the patch in a way that can roll back on error
-      this.saveTransactions(block, db)
-      await this.decryptMyUtxos(
-        block.body.txs,
-        this.tracker.transferTrackers,
-        tokenRegistry,
-        db,
-      )
-      this.saveMyWithdrawals(
-        block.body.txs,
-        this.tracker.withdrawalTrackers,
-        db,
-      )
-      await this.applyPatch(patch, db)
-      // Mark as verified
-      db.update('Proposal', {
-        where: { hash: block.hash.toString() },
-        update: {
-          verified: true,
-          isUncle: isUncle ? true : null,
-        },
-      })
-    })
+    await this.db.transaction(
+      async db => {
+        enableTreeCache()
+        clearTreeCache()
+        this.saveTransactions(block, db)
+        await this.decryptMyUtxos(
+          block.body.txs,
+          this.tracker.transferTrackers,
+          tokenRegistry,
+          db,
+        )
+        this.saveMyWithdrawals(
+          block.body.txs,
+          this.tracker.withdrawalTrackers,
+          db,
+        )
+        await this.applyPatch(patch, db)
+        // Mark as verified
+        db.update('Proposal', {
+          where: { hash: block.hash.toString() },
+          update: {
+            verified: true,
+            isUncle: isUncle ? true : null,
+          },
+        })
+      },
+      () => {
+        disableTreeCache()
+        clearTreeCache()
+      },
+    )
     // TODO remove proposal data if it completes verification or if the block is finalized
     return proposal.proposalNum
   }

--- a/packages/core/src/validator/validator.ts
+++ b/packages/core/src/validator/validator.ts
@@ -205,7 +205,7 @@ export abstract class ValidatorBase {
     const deposits = retrievedDeposits.map(deposit =>
       Fp.from(deposit.note).toUint256(),
     )
-    const startingLeafProof = this.layer2.grove.utxoTree.getStartingLeafProof()
+    const startingLeafProof = await this.layer2.grove.utxoTree.getStartingLeafProof()
     if (
       !parent.utxoRoot.toBN().eq(startingLeafProof.root) ||
       !parent.utxoIndex.toBN().eq(startingLeafProof.index)
@@ -237,7 +237,7 @@ export abstract class ValidatorBase {
   ): Promise<ValidateFnCalls> {
     const onchainValidator = this.onchain.withdrawalTree
     const offchainValidator = this.offchain.withdrawalTree
-    const startingLeafProof = this.layer2.grove.withdrawalTree.getStartingLeafProof()
+    const startingLeafProof = await this.layer2.grove.withdrawalTree.getStartingLeafProof()
     if (
       !parent.withdrawalRoot.toBN().eq(startingLeafProof.root) ||
       !parent.withdrawalIndex.toBN().eq(startingLeafProof.index)

--- a/packages/database/src/block-cache.ts
+++ b/packages/database/src/block-cache.ts
@@ -104,6 +104,7 @@ export class BlockCache {
         await this.writeChange(op)
         docsToRemove.push(op)
       } catch (err) {
+        console.log(err)
         console.log(`Error writing document`)
       }
     }

--- a/packages/database/src/connectors/postgres.ts
+++ b/packages/database/src/connectors/postgres.ts
@@ -24,6 +24,7 @@ import {
   upsertSql,
 } from '../helpers/sql'
 import { loadIncluded } from '../helpers/shared'
+import { execAndCallback } from '../helpers/callbacks'
 
 export class PostgresConnector extends DB {
   db: Client
@@ -209,6 +210,7 @@ export class PostgresConnector extends DB {
     const onCommitCallbacks = [] as Function[]
     const onErrorCallbacks = [] as Function[]
     const onCompleteCallbacks = [] as Function[]
+    if (onComplete) onCompleteCallbacks.push(onComplete)
     const transactionDB = {
       create: (collection: string, _doc: any) => {
         const table = this.schema[collection]
@@ -252,33 +254,26 @@ export class PostgresConnector extends DB {
         onCompleteCallbacks.push(cb)
       },
     }
-    try {
-      await Promise.resolve(operation(transactionDB))
-    } catch (err) {
-      for (const cb of [...onErrorCallbacks, ...onCompleteCallbacks]) {
-        cb()
-      }
-      if (onComplete) onComplete()
-      throw err
-    }
-    try {
-      // now apply the transaction
-      const transactionSql = `BEGIN TRANSACTION;
-      ${sqlOperations.join('\n')}
-      COMMIT;`
-      await this.db.query(transactionSql)
-      for (const cb of [...onCommitCallbacks, ...onCompleteCallbacks]) {
-        cb()
-      }
-      if (onComplete) onComplete()
-    } catch (err) {
-      await this.db.query('ROLLBACK;')
-      for (const cb of [...onErrorCallbacks, ...onCompleteCallbacks]) {
-        cb()
-      }
-      if (onComplete) onComplete()
-      throw err
-    }
+    await execAndCallback(
+      async function(this: any) {
+        await Promise.resolve(operation(transactionDB))
+        // now apply the transaction
+        try {
+          const transactionSql = `BEGIN TRANSACTION;
+        ${sqlOperations.join('\n')}
+        COMMIT;`
+          await this.db.query(transactionSql)
+        } catch (err) {
+          await this.db.query('ROLLBACK;')
+          throw err
+        }
+      }.bind(this),
+      {
+        onSuccess: onCommitCallbacks,
+        onError: onErrorCallbacks,
+        onComplete: onCompleteCallbacks,
+      },
+    )
   }
 
   async close() {

--- a/packages/database/src/connectors/sqlite-memory.ts
+++ b/packages/database/src/connectors/sqlite-memory.ts
@@ -31,7 +31,7 @@ export class SQLiteMemoryConnector extends DB {
 
   schema: Schema = {}
 
-  lock = new AsyncLock()
+  lock = new AsyncLock({ maxPending: 100000 })
 
   constructor() {
     super()
@@ -197,12 +197,17 @@ export class SQLiteMemoryConnector extends DB {
     return this.db.getRowsModified()
   }
 
-  async transaction(operation: (db: TransactionDB) => void) {
-    return this.lock.acquire('write', async () => this._transaction(operation))
+  async transaction(operation: (db: TransactionDB) => void, cb?: () => void) {
+    return this.lock.acquire('write', async () =>
+      this._transaction(operation, cb),
+    )
   }
 
   // Allow only updates, upserts, deletes, and creates
-  private async _transaction(operation: (db: TransactionDB) => void) {
+  private async _transaction(
+    operation: (db: TransactionDB) => void,
+    onComplete?: () => void,
+  ) {
     if (typeof operation !== 'function') throw new Error('Invalid operation')
     const sqlOperations = [] as string[]
     const onCommitCallbacks = [] as Function[]
@@ -251,21 +256,31 @@ export class SQLiteMemoryConnector extends DB {
         onCompleteCallbacks.push(cb)
       },
     }
-    await Promise.resolve(operation(transactionDB))
-    // now apply the transaction
-    const transactionSql = `BEGIN TRANSACTION;
-    ${sqlOperations.join('\n')}
-    COMMIT;`
     try {
+      await Promise.resolve(operation(transactionDB))
+    } catch (err) {
+      for (const cb of [...onErrorCallbacks, ...onCompleteCallbacks]) {
+        cb()
+      }
+      if (onComplete) onComplete()
+      throw err
+    }
+    try {
+      // now apply the transaction
+      const transactionSql = `BEGIN TRANSACTION;
+      ${sqlOperations.join('\n')}
+      COMMIT;`
       await this.db.exec(transactionSql)
       for (const cb of [...onCommitCallbacks, ...onCompleteCallbacks]) {
         cb()
       }
+      if (onComplete) onComplete()
     } catch (err) {
       await this.db.exec('ROLLBACK;')
       for (const cb of [...onErrorCallbacks, ...onCompleteCallbacks]) {
         cb()
       }
+      if (onComplete) onComplete()
       throw err
     }
   }

--- a/packages/database/src/connectors/sqlite.ts
+++ b/packages/database/src/connectors/sqlite.ts
@@ -36,7 +36,7 @@ export class SQLiteConnector extends DB {
 
   schema: Schema = {}
 
-  lock = new AsyncLock()
+  lock = new AsyncLock({ maxPending: 100000 })
 
   constructor(config: any /* ISqlite.Config */) {
     super()
@@ -216,12 +216,17 @@ export class SQLiteConnector extends DB {
     return changes || 0
   }
 
-  async transaction(operation: (db: TransactionDB) => void) {
-    return this.lock.acquire('write', async () => this._transaction(operation))
+  async transaction(operation: (db: TransactionDB) => void, cb?: () => void) {
+    return this.lock.acquire('write', async () =>
+      this._transaction(operation, cb),
+    )
   }
 
   // Allow only updates, upserts, deletes, and creates
-  private async _transaction(operation: (db: TransactionDB) => void) {
+  private async _transaction(
+    operation: (db: TransactionDB) => void,
+    onComplete?: () => void,
+  ) {
     if (typeof operation !== 'function') throw new Error('Invalid operation')
     const sqlOperations = [] as string[]
     const onCommitCallbacks = [] as Function[]
@@ -270,7 +275,15 @@ export class SQLiteConnector extends DB {
         onCompleteCallbacks.push(cb)
       },
     }
-    await Promise.resolve(operation(transactionDB))
+    try {
+      await Promise.resolve(operation(transactionDB))
+    } catch (err) {
+      for (const cb of [...onErrorCallbacks, ...onCompleteCallbacks]) {
+        cb()
+      }
+      if (onComplete) onComplete()
+      throw err
+    }
     // now apply the transaction
     const transactionSql = `BEGIN TRANSACTION;
     ${sqlOperations.join('\n')}
@@ -280,12 +293,14 @@ export class SQLiteConnector extends DB {
       for (const cb of [...onCommitCallbacks, ...onCompleteCallbacks]) {
         cb()
       }
+      if (onComplete) onComplete()
     } catch (err) {
       console.log('SQL error', transactionSql)
       await this.db.exec('ROLLBACK;')
       for (const cb of [...onErrorCallbacks, ...onCompleteCallbacks]) {
         cb()
       }
+      if (onComplete) onComplete()
       throw err
     }
   }

--- a/packages/database/src/helpers/callbacks.ts
+++ b/packages/database/src/helpers/callbacks.ts
@@ -1,0 +1,27 @@
+export async function execAndCallback(
+  operation: () => Promise<any>,
+  funcs: {
+    onError: Function[]
+    onSuccess: Function[]
+    onComplete: Function[]
+  },
+) {
+  try {
+    const result = await operation()
+    for (const cb of [...funcs.onSuccess, ...funcs.onComplete]) {
+      await Promise.resolve(cb()).catch(err => {
+        console.error(err)
+        console.warn('Uncaught error in DB transaction success callback')
+      })
+    }
+    return result
+  } catch (err) {
+    for (const cb of [...funcs.onError, ...funcs.onComplete]) {
+      await Promise.resolve(cb()).catch(err => {
+        console.error(err)
+        console.warn('Uncaught error in DB transaction error callback')
+      })
+    }
+    throw err
+  }
+}

--- a/packages/database/src/preset.ts
+++ b/packages/database/src/preset.ts
@@ -37,7 +37,7 @@ export async function getCachedSiblings(
   treeId: string,
   leafIndex: F,
 ): Promise<TreeNode[]> {
-  const siblingIndexes = Array(depth).fill('')
+  const siblingIndexes = Array(depth).fill(null)
   const leafPath = new BN(1).shln(depth).or(Fp.toBN(leafIndex))
   if (leafPath.lte(Fp.toBN(leafIndex)))
     throw Error('Leaf index is out of range')

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -110,7 +110,10 @@ export abstract class DB {
     options: DeleteManyOptions,
   ): Promise<number>
 
-  abstract transaction(operation: (db: TransactionDB) => void): Promise<void>
+  abstract transaction(
+    operation: (db: TransactionDB) => void,
+    onComplete?: () => void,
+  ): Promise<void>
 
   // close the db and cleanup
   abstract close(): Promise<void>

--- a/packages/dataset/src/testset-predefined.ts
+++ b/packages/dataset/src/testset-predefined.ts
@@ -1,10 +1,13 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import { ZkAccount } from '@zkopru/account'
 import { TokenUtils } from '@zkopru/transaction'
-import { hexify } from '@zkopru/utils'
+import { trimHexToLength } from '@zkopru/utils'
 
-const alicePrivKey = hexify("I am Alice's private key")
-const bobPrivKey = hexify("I am Bob's private key")
+const alicePrivKey = trimHexToLength(Buffer.from("I am Alice's private key"), 64)
+const bobPrivKey = trimHexToLength(
+  Buffer.from("I am Bob's private key").toString('hex'),
+  64,
+)
 const alice = new ZkAccount(alicePrivKey)
 const bob = new ZkAccount(bobPrivKey)
 

--- a/packages/dataset/src/testset-predefined.ts
+++ b/packages/dataset/src/testset-predefined.ts
@@ -3,7 +3,10 @@ import { ZkAccount } from '@zkopru/account'
 import { TokenUtils } from '@zkopru/transaction'
 import { trimHexToLength } from '@zkopru/utils'
 
-const alicePrivKey = trimHexToLength(Buffer.from("I am Alice's private key"), 64)
+const alicePrivKey = trimHexToLength(
+  Buffer.from("I am Alice's private key"),
+  64,
+)
 const bobPrivKey = trimHexToLength(
   Buffer.from("I am Bob's private key").toString('hex'),
   64,

--- a/packages/integration-test/tests/cases/6_zk_tx_round_1.ts
+++ b/packages/integration-test/tests/cases/6_zk_tx_round_1.ts
@@ -21,6 +21,7 @@ export const buildZkTxAliceSendEthToBob = async (
 
   const alicePrevBalance = await aliceWallet.getSpendableAmount(alice)
   const aliceSpendables: Utxo[] = await aliceWallet.getSpendables(alice)
+  const alicePrevLocked = await aliceWallet.getLockedAmount(alice)
   const aliceRawTx = TxBuilder.from(alice.zkAddress)
     .provide(...aliceSpendables.map(note => Utxo.from(note)))
     .weiPerByte(toWei('100000', 'gwei'))
@@ -35,7 +36,7 @@ export const buildZkTxAliceSendEthToBob = async (
   const aliceNewBalance = await aliceWallet.getSpendableAmount(alice)
   const aliceLockedAmount = await aliceWallet.getLockedAmount(alice)
   expect(aliceNewBalance.eth.add(aliceLockedAmount.eth)).toBe(
-    alicePrevBalance.eth,
+    alicePrevBalance.eth.add(alicePrevLocked.eth),
   )
   // const aliceResponse = await aliceWallet.sendLayer2Tx(aliceZkTx)
   // expect(aliceResponse.status).toStrictEqual(200)
@@ -51,6 +52,9 @@ export const buildZkTxBobSendERC20ToCarl = async (
   const { carl } = accounts
   const tokenAddr = tokens.erc20.address
   const bobPrevBalance = (await bobWallet.getSpendableAmount(bob)).getERC20(
+    tokenAddr,
+  )
+  const bobPrevLocked = (await bobWallet.getLockedAmount(bob)).getERC20(
     tokenAddr,
   )
   const bobSpendables: Utxo[] = await bobWallet.getSpendables(bob)
@@ -75,7 +79,9 @@ export const buildZkTxBobSendERC20ToCarl = async (
     tokenAddr,
   )
   // expect(response.status).toStrictEqual(200)
-  expect(bobNewBalance.add(bobLockedAmount)).toBe(bobPrevBalance)
+  expect(bobNewBalance.add(bobLockedAmount)).toBe(
+    bobPrevBalance.add(bobPrevLocked),
+  )
   return bobZkTx
 }
 

--- a/packages/integration-test/tests/cases/7_zk_tx_round_2.ts
+++ b/packages/integration-test/tests/cases/7_zk_tx_round_2.ts
@@ -58,6 +58,7 @@ export const buildZkTxBobWithdrawEth = async (
   const bobWallet = wallets.bob
   const { bob } = accounts
   const bobPrevBalance = (await bobWallet.getSpendableAmount(bob)).eth
+  const bobPrevLocked = await bobWallet.getLockedAmount(bob)
   const bobSpendables: Utxo[] = await bobWallet.getSpendables(bob)
   const bobRawTx = TxBuilder.from(bob.zkAddress)
     .provide(...bobSpendables.map(note => Utxo.from(note)))
@@ -78,7 +79,9 @@ export const buildZkTxBobWithdrawEth = async (
   const bobNewBalance = (await bobWallet.getSpendableAmount(bob)).eth
   const bobLockedAmount = (await bobWallet.getLockedAmount(bob)).eth
   // expect(response.status).toStrictEqual(200)
-  expect(bobNewBalance.add(bobLockedAmount)).toBe(bobPrevBalance)
+  expect(bobNewBalance.add(bobLockedAmount)).toBe(
+    bobPrevBalance.add(bobPrevLocked.eth),
+  )
   return bobWithdrawal
 }
 
@@ -90,6 +93,9 @@ export const buildZkTxCarlWithdrawErc20 = async (
   const { carl } = accounts
   const tokenAddr = tokens.erc20.address
   const carlPrevBalance = (await carlWallet.getSpendableAmount(carl)).getERC20(
+    tokenAddr,
+  )
+  const carlPrevLocked = (await carlWallet.getLockedAmount(carl)).getERC20(
     tokenAddr,
   )
   const carlSpendables: Utxo[] = await carlWallet.getSpendables(carl)
@@ -118,7 +124,9 @@ export const buildZkTxCarlWithdrawErc20 = async (
     tokenAddr,
   )
   // expect(response.status).toStrictEqual(200)
-  expect(carlNewBalance.add(carlLockedAmount)).toBe(carlPrevBalance)
+  expect(carlNewBalance.add(carlLockedAmount)).toBe(
+    carlPrevBalance.add(carlPrevLocked),
+  )
   return carlWithdrawal
 }
 

--- a/packages/integration-test/tests/cases/9_zk_tx_round_3.ts
+++ b/packages/integration-test/tests/cases/9_zk_tx_round_3.ts
@@ -21,6 +21,7 @@ export const buildZkTxAliceSendEthToBob = async (
   const { bob } = accounts
 
   const alicePrevBalance = await aliceWallet.getSpendableAmount(alice)
+  const alicePrevLocked = await aliceWallet.getLockedAmount(alice)
   const aliceSpendables: Utxo[] = await aliceWallet.getSpendables(alice)
   const aliceRawTx = TxBuilder.from(alice.zkAddress)
     .provide(...aliceSpendables.map(note => Utxo.from(note)))
@@ -36,7 +37,7 @@ export const buildZkTxAliceSendEthToBob = async (
   const aliceNewBalance = await aliceWallet.getSpendableAmount(alice)
   const aliceLockedAmount = await aliceWallet.getLockedAmount(alice)
   expect(aliceNewBalance.eth.add(aliceLockedAmount.eth)).toBe(
-    alicePrevBalance.eth,
+    alicePrevBalance.eth.add(alicePrevLocked.eth),
   )
   return aliceZkTx
 }
@@ -80,6 +81,7 @@ export const buildZkTxCarlSendEthToAlice = async (
   const { alice } = accounts
 
   const carlPrevBalance = await carlWallet.getSpendableAmount(carl)
+  const carlPrevLocked = await carlWallet.getLockedAmount(carl)
   const carlSpendables: Utxo[] = await carlWallet.getSpendables(carl)
   const carlRawTx = TxBuilder.from(carl.zkAddress)
     .provide(...carlSpendables.map(note => Utxo.from(note)))
@@ -94,7 +96,9 @@ export const buildZkTxCarlSendEthToAlice = async (
   })
   const carlNewBalance = await carlWallet.getSpendableAmount(carl)
   const carlLockedAmount = await carlWallet.getLockedAmount(carl)
-  expect(carlNewBalance.eth.add(carlLockedAmount.eth)).toBe(carlPrevBalance.eth)
+  expect(carlNewBalance.eth.add(carlLockedAmount.eth)).toBe(
+    carlPrevBalance.eth.add(carlPrevLocked.eth),
+  )
   return carlZkTx
 }
 

--- a/packages/integration-test/tests/cases/9_zk_tx_round_3.ts
+++ b/packages/integration-test/tests/cases/9_zk_tx_round_3.ts
@@ -51,6 +51,7 @@ export const buildZkTxBobSendEthToCarl = async (
 
   const bobPrevBalance = await bobWallet.getSpendableAmount(bob)
   const bobSpendables: Utxo[] = await bobWallet.getSpendables(bob)
+  const bobPrevLocked = await bobWallet.getLockedAmount(bob)
   const bobRawTx = TxBuilder.from(bob.zkAddress)
     .provide(...bobSpendables.map(note => Utxo.from(note)))
     .weiPerByte(toWei('100000', 'gwei'))
@@ -64,7 +65,9 @@ export const buildZkTxBobSendEthToCarl = async (
   })
   const bobNewBalance = await bobWallet.getSpendableAmount(bob)
   const bobLockedAmount = await bobWallet.getLockedAmount(bob)
-  expect(bobNewBalance.eth.add(bobLockedAmount.eth)).toBe(bobPrevBalance.eth)
+  expect(bobNewBalance.eth.add(bobLockedAmount.eth)).toBe(
+    bobPrevBalance.eth.add(bobPrevLocked.eth),
+  )
   return bobZkTx
 }
 

--- a/packages/integration-test/tests/cases/9_zk_tx_round_3.ts
+++ b/packages/integration-test/tests/cases/9_zk_tx_round_3.ts
@@ -105,14 +105,12 @@ export const testRound3SendZkTxsToCoordinator = (
 ) => async () => {
   const { wallets } = ctx()
   const { aliceTransfer, bobTransfer, carlTransfer } = txs()
-  const [response1, response2, response3] = await Promise.all([
-    wallets.alice.sendLayer2Tx(aliceTransfer),
-    wallets.bob.sendLayer2Tx(bobTransfer),
-    wallets.carl.sendLayer2Tx(carlTransfer),
+  const r = await wallets.alice.sendLayer2Tx([
+    aliceTransfer,
+    bobTransfer,
+    carlTransfer,
   ])
-  expect(response1.status).toStrictEqual(200)
-  expect(response2.status).toStrictEqual(200)
-  expect(response3.status).toStrictEqual(200)
+  expect(r.status).toStrictEqual(200)
 }
 
 export const testRound3NewBlockProposalAndSlashing = (

--- a/packages/tree/src/grove.ts
+++ b/packages/tree/src/grove.ts
@@ -349,7 +349,7 @@ export class Grove {
     index?: BN,
   ): Promise<MerkleProof<BN>> {
     const withdrawal = await this.db.findOne('Withdrawal', {
-      where: { hash: noteHash.toString(10) },
+      where: { withdrawalHash: noteHash.toString(10) },
     })
     if (!withdrawal) throw Error('Failed to find the withdrawal')
     const leafIndex = index?.toString() || withdrawal.index
@@ -377,7 +377,7 @@ export class Grove {
     const proof = {
       root,
       index: toBN(leafIndex),
-      leaf: toBN(withdrawal.withdrawalHash),
+      leaf: noteHash,
       siblings,
     }
     const isValid = verifyProof(this.config.withdrawalHasher, proof)

--- a/packages/tree/src/light-rollup-tree.ts
+++ b/packages/tree/src/light-rollup-tree.ts
@@ -393,10 +393,12 @@ export abstract class LightRollUpTree<T extends Fp | BN> {
     // update the latest siblings
     const backupData = { ...this.data }
     const backupMetadata = { ...this.metadata }
-    db.onError(() => {
-      // be careful of deep properties that are not copied
-      this.data = backupData
-      this.metadata = backupMetadata
+    db.onError(async () => {
+      await this.lock.acquire('root', () => {
+        // be careful of deep properties that are not copied
+        this.data = backupData
+        this.metadata = backupMetadata
+      })
     })
     this.data = {
       root,

--- a/packages/tree/src/light-rollup-tree.ts
+++ b/packages/tree/src/light-rollup-tree.ts
@@ -391,6 +391,13 @@ export abstract class LightRollUpTree<T extends Fp | BN> {
     }
     const end: T = start.addn(leaves.length) as T
     // update the latest siblings
+    const backupData = { ...this.data }
+    const backupMetadata = { ...this.metadata }
+    db.onError(() => {
+      // be careful of deep properties that are not copied
+      this.data = backupData
+      this.metadata = backupMetadata
+    })
     this.data = {
       root,
       index: end,

--- a/packages/tree/src/light-rollup-tree.ts
+++ b/packages/tree/src/light-rollup-tree.ts
@@ -10,7 +10,6 @@ import {
   TreeSpecies,
   getCachedSiblings,
   cacheTreeNode,
-  clearTreeCache,
   TransactionDB,
 } from '@zkopru/database'
 import { Hasher } from './hasher'
@@ -448,7 +447,6 @@ export abstract class LightRollUpTree<T extends Fp | BN> {
         },
       })
     }
-    db.onComplete(() => clearTreeCache())
     return {
       root,
       index: end,

--- a/packages/tree/src/light-rollup-tree.ts
+++ b/packages/tree/src/light-rollup-tree.ts
@@ -192,25 +192,27 @@ export abstract class LightRollUpTree<T extends Fp | BN> {
     })
   }
 
-  getStartingLeafProof(): {
+  async getStartingLeafProof(): Promise<{
     root: T
     index: T
     siblings: T[]
-  } {
-    const index = this.latestLeafIndex()
-    const siblings: T[] = [...this.data.siblings]
-    let path: BN = index
-    for (let i = 0; i < this.depth; i += 1) {
-      if (path.isEven()) {
-        siblings[i] = this.config.hasher.preHash[i]
+  }> {
+    return this.lock.acquire('root', async () => {
+      const index = this.latestLeafIndex()
+      const siblings: T[] = [...this.data.siblings]
+      let path: BN = index
+      for (let i = 0; i < this.depth; i += 1) {
+        if (path.isEven()) {
+          siblings[i] = this.config.hasher.preHash[i]
+        }
+        path = path.shrn(1)
       }
-      path = path.shrn(1)
-    }
-    return {
-      root: this.root(),
-      index,
-      siblings,
-    }
+      return {
+        root: this.root(),
+        index,
+        siblings,
+      }
+    })
   }
 
   private async _merkleProof({

--- a/packages/tree/src/nullifier-tree.ts
+++ b/packages/tree/src/nullifier-tree.ts
@@ -271,6 +271,12 @@ export class NullifierTree implements SMT<BN> {
     }
     const newRoot = updatedNodes[hexify(new BN(1))]
     logger.trace(`setting new root - ${newRoot}`)
+    const oldRoot = new BN(this.rootNode)
+    db.onError(async () => {
+      await this.lock.acquire('root', () => {
+        this.rootNode = oldRoot
+      })
+    })
     this.rootNode = newRoot
     return this.rootNode
   }

--- a/packages/tree/src/nullifier-tree.ts
+++ b/packages/tree/src/nullifier-tree.ts
@@ -10,7 +10,6 @@ import {
   NULLIFIER_TREE_ID,
   getCachedSiblings,
   cacheTreeNode,
-  clearTreeCache,
   TransactionDB,
 } from '@zkopru/database'
 import { Hasher, genesisRoot } from './hasher'
@@ -270,7 +269,6 @@ export class NullifierTree implements SMT<BN> {
         },
       })
     }
-    db.onComplete(() => clearTreeCache())
     const newRoot = updatedNodes[hexify(new BN(1))]
     logger.trace(`setting new root - ${newRoot}`)
     this.rootNode = newRoot

--- a/packages/tree/tests/unit/grove.test.ts
+++ b/packages/tree/tests/unit/grove.test.ts
@@ -145,11 +145,11 @@ describe('grove full sync grove()', () => {
       const { withdrawalTree } = fullSyncGrove
       const bootstrapData = {
         utxoStartingLeafProof: {
-          ...utxoTree.getStartingLeafProof(),
+          ...(await utxoTree.getStartingLeafProof()),
           leaf: Fp.zero,
         },
         withdrawalStartingLeafProof: {
-          ...withdrawalTree.getStartingLeafProof(),
+          ...(await withdrawalTree.getStartingLeafProof()),
           leaf: toBN(0),
         },
       }

--- a/packages/tree/tests/unit/grove.test.ts
+++ b/packages/tree/tests/unit/grove.test.ts
@@ -49,7 +49,7 @@ describe('grove full sync grove()', () => {
     })
   })
   describe('dryPatch', () => {
-    it.skip('should not update the grove', async () => {
+    it('should not update the grove', async () => {
       const prevResult = {
         utxoRoot: fullSyncGrove.utxoTree.root(),
         utxoIndex: fullSyncGrove.utxoTree.latestLeafIndex(),
@@ -100,7 +100,7 @@ describe('grove full sync grove()', () => {
     }, 60000)
   })
   describe('applyPatch()', () => {
-    it.skip('should update the grove and have same result with the dry patch result', async () => {
+    it('should update the grove and have same result with the dry patch result', async () => {
       const utxosToAppend: Leaf<Fp>[] = [
         utxos.utxo1_out_1,
         utxos.utxo2_1_in_1,
@@ -141,7 +141,7 @@ describe('grove full sync grove()', () => {
     }, 300000)
   })
   describe('light sync grove - applyBootstrap()', () => {
-    it.skip('should update the grove using bootstrap data', async () => {
+    it('should update the grove using bootstrap data', async () => {
       const { utxoTree } = fullSyncGrove
       const { withdrawalTree } = fullSyncGrove
       const bootstrapData = {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -137,7 +137,7 @@ export function hexify(
       hex = n.substr(2)
     } else {
       try {
-        hex = new BN(n, 16).toString(16)
+        hex = new BN(n).toString(16)
       } catch (e) {
         hex = Buffer.from(n).toString('hex')
       }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -136,11 +136,10 @@ export function hexify(
     if (n.startsWith('0x')) {
       hex = n.substr(2)
     } else {
-      try {
-        hex = new BN(n).toString(16)
-      } catch (e) {
-        hex = Buffer.from(n).toString('hex')
+      if (/[a-fA-F]/.test(n)) {
+        throw new Error('Detected hex value in expected decimal string')
       }
+      hex = new BN(n).toString(16)
     }
   } else {
     hex = n.toString('hex')

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -153,6 +153,24 @@ export function hexify(
   return `0x${hex}`
 }
 
+export function trimHexToLength(
+  hexstring: string | Buffer,
+  targetLength: number,
+) {
+  const rawString = (typeof hexstring === 'string'
+    ? hexstring
+    : hexstring.toString('hex')
+  ).replace('0x', '')
+  const reducedString = rawString.slice(0, targetLength)
+  const filledString = [
+    reducedString,
+    ...Array(targetLength - reducedString.length)
+      .fill(null)
+      .map(() => '0'),
+  ].join('')
+  return `0x${filledString}`
+}
+
 export function numToBuffer(
   decimal: BN | string | number,
   len?: number,


### PR DESCRIPTION
Refactors transaction history calculation logic.

Uses multi tx endpoint for integration test round 3 transactions.

Fixes a race condition in light rollup tree `getStartingLeafProof` (fixes intermittent withdrawal problem).

Adds revert logic for rollup tree state variables.

Adds merkle proof test against external SMT implementation.

Change hexify, reject hexadecimal string without `0x` prefix.

async db tx callback support

Includes #266 

Closes #268 