### PR TITLE
Fix global tree cache

### DIFF
--- a/packages/core/src/node/block-processor.ts
+++ b/packages/core/src/node/block-processor.ts
@@ -7,9 +7,6 @@ import {
   Proposal,
   MassDeposit as MassDepositSql,
   TransactionDB,
-  clearTreeCache,
-  enableTreeCache,
-  disableTreeCache,
 } from '@zkopru/database'
 import { logger, Worker } from '@zkopru/utils'
 import assert from 'assert'
@@ -217,8 +214,8 @@ export class BlockProcessor extends EventEmitter {
     const patch = await this.makePatch(parent, block)
     await this.db.transaction(
       async db => {
-        enableTreeCache()
-        clearTreeCache()
+        this.layer2.grove.treeCache.enable()
+        this.layer2.grove.treeCache.clear()
         this.saveTransactions(block, db)
         await this.decryptMyUtxos(
           block.body.txs,
@@ -242,8 +239,8 @@ export class BlockProcessor extends EventEmitter {
         })
       },
       () => {
-        disableTreeCache()
-        clearTreeCache()
+        this.layer2.grove.treeCache.disable()
+        this.layer2.grove.treeCache.clear()
       },
     )
     // TODO remove proposal data if it completes verification or if the block is finalized

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -40,7 +40,6 @@ export const NULLIFIER_TREE_ID = 'nullifier-tree'
 
 export * from './types'
 export * from './schema.types'
-export * from './preset'
 export * from './block-cache'
 export * from './helpers/memory'
 export { schema }

--- a/packages/database/src/preset.ts
+++ b/packages/database/src/preset.ts
@@ -8,59 +8,62 @@ import { DB } from './types'
 //
 // This is used during block synchronization to allow updated data to be used
 // before a database transaction is finished (see block-processor.ts)
-const cachedTreeNodes = {} as { [key: string]: any }
 
-let cacheEnabled = false
+export class TreeCache {
+  enabled = false
 
-export function cacheTreeNode(treeId: string, nodeIndex: string, node: any) {
-  if (!cacheEnabled) return
-  cachedTreeNodes[`${treeId}-${nodeIndex}`] = node
-}
+  cachedTreeNodes = {} as { [key: string]: any }
 
-export function enableTreeCache() {
-  cacheEnabled = true
-}
-
-export function disableTreeCache() {
-  cacheEnabled = true
-}
-
-export function clearTreeCache() {
-  for (const key of Object.keys(cachedTreeNodes)) {
-    delete cachedTreeNodes[key]
+  cacheNode(treeId: string, nodeIndex: string, node: any) {
+    if (this.enabled) return
+    this.cachedTreeNodes[`${treeId}-${nodeIndex}`] = node
   }
-}
 
-export async function getCachedSiblings(
-  db: DB,
-  depth: number,
-  treeId: string,
-  leafIndex: F,
-): Promise<TreeNode[]> {
-  const siblingIndexes = Array(depth).fill(null)
-  const leafPath = new BN(1).shln(depth).or(Fp.toBN(leafIndex))
-  if (leafPath.lte(Fp.toBN(leafIndex)))
-    throw Error('Leaf index is out of range')
-
-  for (let level = 0; level < depth; level += 1) {
-    const pathIndex = leafPath.shrn(level)
-    const siblingIndex = new BN(1).xor(pathIndex)
-    siblingIndexes[level] = hexify(siblingIndex)
+  enable() {
+    this.enabled = true
   }
-  const inMemoryNodes = cacheEnabled
-    ? siblingIndexes
-        .map(index => cachedTreeNodes[`${treeId}-${index}`])
-        .filter(node => !!node)
-    : []
-  const uncachedSiblingIndexes = siblingIndexes.filter(index => {
-    if (!cacheEnabled) return true
-    return !cachedTreeNodes[`${treeId}-${index}`]
-  })
-  const cachedSiblings = await db.findMany('TreeNode', {
-    where: {
-      treeId,
-      nodeIndex: uncachedSiblingIndexes,
-    },
-  })
-  return [...inMemoryNodes, ...cachedSiblings]
+
+  disable() {
+    this.enabled = false
+  }
+
+  clear() {
+    for (const key of Object.keys(this.cachedTreeNodes)) {
+      delete this.cachedTreeNodes[key]
+    }
+  }
+
+  async getCachedSiblings(
+    db: DB,
+    depth: number,
+    treeId: string,
+    leafIndex: F,
+  ): Promise<TreeNode[]> {
+    const siblingIndexes = Array(depth).fill(null)
+    const leafPath = new BN(1).shln(depth).or(Fp.toBN(leafIndex))
+    if (leafPath.lte(Fp.toBN(leafIndex)))
+      throw Error('Leaf index is out of range')
+
+    for (let level = 0; level < depth; level += 1) {
+      const pathIndex = leafPath.shrn(level)
+      const siblingIndex = new BN(1).xor(pathIndex)
+      siblingIndexes[level] = hexify(siblingIndex)
+    }
+    const inMemoryNodes = this.enabled
+      ? siblingIndexes
+          .map(index => this.cachedTreeNodes[`${treeId}-${index}`])
+          .filter(node => !!node)
+      : []
+    const uncachedSiblingIndexes = siblingIndexes.filter(index => {
+      if (!this.enabled) return true
+      return !this.cachedTreeNodes[`${treeId}-${index}`]
+    })
+    const cachedSiblings = await db.findMany('TreeNode', {
+      where: {
+        treeId,
+        nodeIndex: uncachedSiblingIndexes,
+      },
+    })
+    return [...inMemoryNodes, ...cachedSiblings]
+  }
 }

--- a/packages/database/src/preset.ts
+++ b/packages/database/src/preset.ts
@@ -15,7 +15,7 @@ export class TreeCache {
   cachedTreeNodes = {} as { [key: string]: any }
 
   cacheNode(treeId: string, nodeIndex: string, node: any) {
-    if (this.enabled) return
+    if (!this.enabled) return
     this.cachedTreeNodes[`${treeId}-${nodeIndex}`] = node
   }
 

--- a/packages/integration-test/package.json
+++ b/packages/integration-test/package.json
@@ -21,7 +21,7 @@
     "build": "tsc --build tsconfig.build.json",
     "clean": "tsc --build tsconfig.build.json --clean && shx rm -rf coverage *.log junit.xml dist && jest --clearCache",
     "link-modules": "link-module-alias",
-    "test": "jest --bail=1",
+    "test": "jest --bail=1 --forceExit",
     "test:unit": "jest test/unit",
     "test:watch": "jest --watch",
     "test:ci": "jest --coverage --ci --reporters='jest-junit'",

--- a/packages/integration-test/tests/cases/context.ts
+++ b/packages/integration-test/tests/cases/context.ts
@@ -63,7 +63,6 @@ export async function terminate(ctx: CtxProvider) {
     wallets,
     provider,
   } = ctx()
-  provider.disconnect(0, 'exit')
   await Promise.all([
     coordinator.stop(),
     wallets.alice.node.stop(),
@@ -71,7 +70,9 @@ export async function terminate(ctx: CtxProvider) {
     wallets.carl.node.stop(),
     wallets.coordinator.node.stop(),
   ])
-  await Promise.all([dbs.map(db => db.close())])
+  await new Promise(r => setTimeout(r, 20000))
+  await Promise.all(dbs.map(db => db.close()))
+  provider.disconnect(0, 'exit')
   await Promise.all([
     await layer1Container.stop(),
     await circuitArtifactContainer.stop(),

--- a/packages/tree/src/grove.ts
+++ b/packages/tree/src/grove.ts
@@ -11,7 +11,6 @@ import {
   LightTree,
   TreeNode,
   TransactionDB,
-  TreeCache,
 } from '@zkopru/database'
 import { ZkAddress } from '@zkopru/transaction'
 import { Hasher, genesisRoot } from './hasher'
@@ -20,6 +19,7 @@ import { Leaf } from './light-rollup-tree'
 import { UtxoTree } from './utxo-tree'
 import { WithdrawalTree } from './withdrawal-tree'
 import { NullifierTree } from './nullifier-tree'
+import { TreeCache } from './utils'
 
 export interface GroveConfig {
   utxoTreeDepth: number

--- a/packages/tree/src/index.ts
+++ b/packages/tree/src/index.ts
@@ -28,4 +28,4 @@ export {
   GroveSnapshot as DryPatchResult,
 } from './grove'
 
-export { MerkleTreeLib, SubTreeLib, SMT } from './utils'
+export { TreeCache, MerkleTreeLib, SubTreeLib, SMT } from './utils'

--- a/packages/tree/src/light-rollup-tree.ts
+++ b/packages/tree/src/light-rollup-tree.ts
@@ -5,13 +5,7 @@ import AsyncLock from 'async-lock'
 import BN from 'bn.js'
 import { toBN } from 'web3-utils'
 import { hexify } from '@zkopru/utils'
-import {
-  DB,
-  TreeSpecies,
-  getCachedSiblings,
-  cacheTreeNode,
-  TransactionDB,
-} from '@zkopru/database'
+import { DB, TreeSpecies, TransactionDB, TreeCache } from '@zkopru/database'
 import { Hasher } from './hasher'
 import { MerkleProof, startingLeafProof, verifyProof } from './merkle-proof'
 
@@ -57,18 +51,22 @@ export abstract class LightRollUpTree<T extends Fp | BN> {
 
   lock: AsyncLock
 
+  treeCache: TreeCache
+
   constructor({
     db,
     species,
     metadata,
     data,
     config,
+    treeCache,
   }: {
     db: DB
     species: TreeSpecies
     metadata: TreeMetadata<T>
     data: TreeData<T>
     config: TreeConfig<T>
+    treeCache: TreeCache
   }) {
     this.lock = new AsyncLock()
     this.species = species
@@ -77,6 +75,7 @@ export abstract class LightRollUpTree<T extends Fp | BN> {
     this.data = data
     this.config = config
     this.depth = data.siblings.length
+    this.treeCache = treeCache
   }
 
   root(): T {
@@ -295,7 +294,7 @@ export abstract class LightRollUpTree<T extends Fp | BN> {
   private async _getCachedSiblings(
     leafIndex: T,
   ): Promise<{ [index: string]: string }> {
-    const cachedSiblings = await getCachedSiblings(
+    const cachedSiblings = await this.treeCache.getCachedSiblings(
       this.db,
       this.depth,
       this.metadata.id,
@@ -436,7 +435,7 @@ export abstract class LightRollUpTree<T extends Fp | BN> {
     })
     // update cached nodes
     for (const nodeIndex of Object.keys(cached)) {
-      cacheTreeNode(this.metadata.id, nodeIndex, {
+      this.treeCache.cacheNode(this.metadata.id, nodeIndex, {
         treeId: this.metadata.id,
         nodeIndex,
         value: cached[nodeIndex],

--- a/packages/tree/src/light-rollup-tree.ts
+++ b/packages/tree/src/light-rollup-tree.ts
@@ -5,9 +5,10 @@ import AsyncLock from 'async-lock'
 import BN from 'bn.js'
 import { toBN } from 'web3-utils'
 import { hexify } from '@zkopru/utils'
-import { DB, TreeSpecies, TransactionDB, TreeCache } from '@zkopru/database'
+import { DB, TreeSpecies, TransactionDB } from '@zkopru/database'
 import { Hasher } from './hasher'
 import { MerkleProof, startingLeafProof, verifyProof } from './merkle-proof'
+import { TreeCache } from './utils'
 
 export interface Leaf<T extends Fp | BN> {
   hash: T

--- a/packages/tree/src/nullifier-tree.ts
+++ b/packages/tree/src/nullifier-tree.ts
@@ -9,10 +9,10 @@ import {
   TreeNode,
   NULLIFIER_TREE_ID,
   TransactionDB,
-  TreeCache,
 } from '@zkopru/database'
 import { Hasher, genesisRoot } from './hasher'
 import { verifyProof, MerkleProof } from './merkle-proof'
+import { TreeCache } from './utils'
 
 export interface SMT<T extends Fp | BN> {
   depth: number

--- a/packages/tree/src/sample.ts
+++ b/packages/tree/src/sample.ts
@@ -3,13 +3,13 @@ import {
   SQLiteMemoryConnector,
   TreeSpecies,
   schema,
-  TreeCache,
 } from '@zkopru/database/dist/node'
 import { Fp } from '@zkopru/babyjubjub'
 import { v4 } from 'uuid'
 import { TreeConfig } from './light-rollup-tree'
 import { UtxoTree } from './utxo-tree'
 import { genesisRoot, poseidonHasher } from './hasher'
+import { TreeCache } from './utils'
 
 export default async function sample(
   depth: number,

--- a/packages/tree/src/sample.ts
+++ b/packages/tree/src/sample.ts
@@ -3,6 +3,7 @@ import {
   SQLiteMemoryConnector,
   TreeSpecies,
   schema,
+  TreeCache,
 } from '@zkopru/database/dist/node'
 import { Fp } from '@zkopru/babyjubjub'
 import { v4 } from 'uuid'
@@ -32,11 +33,13 @@ export default async function sample(
     siblings: preHashes.slice(0, -1),
   }
   const mockupDB = await SQLiteMemoryConnector.create(schema)
+  const treeCache = new TreeCache()
   const utxoTree = new UtxoTree({
     db: mockupDB,
     metadata: utxoTreeMetadata,
     data: utxoTreeInitialData,
     config: utxoTreeConfig,
+    treeCache,
   })
   await utxoTree.init()
   return {

--- a/packages/tree/src/utils/index.ts
+++ b/packages/tree/src/utils/index.ts
@@ -33,3 +33,5 @@ export const SMT = {
   merkleProof: smtMerkleProof,
   calculateRoot,
 }
+
+export * from './tree-cache'

--- a/packages/tree/src/utils/tree-cache.ts
+++ b/packages/tree/src/utils/tree-cache.ts
@@ -1,8 +1,7 @@
 import BN from 'bn.js'
 import { Fp, F } from '@zkopru/babyjubjub'
 import { hexify } from '@zkopru/utils'
-import { TreeNode } from './schema.types'
-import { DB } from './types'
+import { DB, TreeNode } from '@zkopru/database'
 
 // An in memory cache for loading tree indexes in a database transaction
 //

--- a/packages/tree/src/utxo-tree.ts
+++ b/packages/tree/src/utxo-tree.ts
@@ -1,5 +1,5 @@
 import { Fp } from '@zkopru/babyjubjub'
-import { DB, LightTree, TreeSpecies } from '@zkopru/database'
+import { DB, LightTree, TreeSpecies, TreeCache } from '@zkopru/database'
 import { ZkAddress } from '@zkopru/transaction'
 import {
   LightRollUpTree,
@@ -14,6 +14,7 @@ export class UtxoTree extends LightRollUpTree<Fp> {
     metadata: TreeMetadata<Fp>
     data: TreeData<Fp>
     config: TreeConfig<Fp>
+    treeCache: TreeCache
   }) {
     super({ ...conf, species: TreeSpecies.UTXO })
   }
@@ -47,11 +48,13 @@ export class UtxoTree extends LightRollUpTree<Fp> {
     metadata,
     data,
     config,
+    treeCache,
   }: {
     db: DB
     metadata: TreeMetadata<Fp>
     data: TreeData<Fp>
     config: TreeConfig<Fp>
+    treeCache: TreeCache
   }): Promise<UtxoTree> {
     const initialData = await LightRollUpTree.initTreeFromDatabase({
       db,
@@ -60,10 +63,15 @@ export class UtxoTree extends LightRollUpTree<Fp> {
       data,
       config,
     })
-    return new UtxoTree({ ...initialData })
+    return new UtxoTree({ ...initialData, treeCache })
   }
 
-  static from(db: DB, obj: LightTree, config: TreeConfig<Fp>): UtxoTree {
+  static from(
+    db: DB,
+    obj: LightTree,
+    config: TreeConfig<Fp>,
+    treeCache: TreeCache,
+  ): UtxoTree {
     return new UtxoTree({
       db,
       metadata: {
@@ -78,6 +86,7 @@ export class UtxoTree extends LightRollUpTree<Fp> {
         siblings: JSON.parse(obj.siblings).map(sib => Fp.from(sib)),
       },
       config,
+      treeCache,
     })
   }
 }

--- a/packages/tree/src/utxo-tree.ts
+++ b/packages/tree/src/utxo-tree.ts
@@ -1,5 +1,5 @@
 import { Fp } from '@zkopru/babyjubjub'
-import { DB, LightTree, TreeSpecies, TreeCache } from '@zkopru/database'
+import { DB, LightTree, TreeSpecies } from '@zkopru/database'
 import { ZkAddress } from '@zkopru/transaction'
 import {
   LightRollUpTree,
@@ -7,6 +7,7 @@ import {
   TreeData,
   TreeConfig,
 } from './light-rollup-tree'
+import { TreeCache } from './utils'
 
 export class UtxoTree extends LightRollUpTree<Fp> {
   constructor(conf: {

--- a/packages/tree/src/withdrawal-tree.ts
+++ b/packages/tree/src/withdrawal-tree.ts
@@ -1,4 +1,4 @@
-import { DB, LightTree, TreeSpecies, TreeCache } from '@zkopru/database'
+import { DB, LightTree, TreeSpecies } from '@zkopru/database'
 import BN from 'bn.js'
 import { toBN } from 'web3-utils'
 import {
@@ -7,6 +7,7 @@ import {
   TreeData,
   TreeConfig,
 } from './light-rollup-tree'
+import { TreeCache } from './utils'
 
 export class WithdrawalTree extends LightRollUpTree<BN> {
   zero = toBN(0)

--- a/packages/tree/src/withdrawal-tree.ts
+++ b/packages/tree/src/withdrawal-tree.ts
@@ -1,4 +1,4 @@
-import { DB, LightTree, TreeSpecies } from '@zkopru/database'
+import { DB, LightTree, TreeSpecies, TreeCache } from '@zkopru/database'
 import BN from 'bn.js'
 import { toBN } from 'web3-utils'
 import {
@@ -18,6 +18,7 @@ export class WithdrawalTree extends LightRollUpTree<BN> {
     metadata: TreeMetadata<BN>
     data: TreeData<BN>
     config: TreeConfig<BN>
+    treeCache: TreeCache
   }) {
     super({ ...conf, species: TreeSpecies.WITHDRAWAL })
   }
@@ -45,11 +46,13 @@ export class WithdrawalTree extends LightRollUpTree<BN> {
     metadata,
     data,
     config,
+    treeCache,
   }: {
     db: DB
     metadata: TreeMetadata<BN>
     data: TreeData<BN>
     config: TreeConfig<BN>
+    treeCache: TreeCache
   }): Promise<WithdrawalTree> {
     const initialData = await LightRollUpTree.initTreeFromDatabase({
       db,
@@ -58,10 +61,15 @@ export class WithdrawalTree extends LightRollUpTree<BN> {
       data,
       config,
     })
-    return new WithdrawalTree({ ...initialData })
+    return new WithdrawalTree({ ...initialData, treeCache })
   }
 
-  static from(db: DB, obj: LightTree, config: TreeConfig<BN>): WithdrawalTree {
+  static from(
+    db: DB,
+    obj: LightTree,
+    config: TreeConfig<BN>,
+    treeCache: TreeCache,
+  ): WithdrawalTree {
     return new WithdrawalTree({
       db,
       metadata: {
@@ -76,6 +84,7 @@ export class WithdrawalTree extends LightRollUpTree<BN> {
         siblings: JSON.parse(obj.siblings).map(toBN),
       },
       config,
+      treeCache,
     })
   }
 }

--- a/packages/tree/tests/unit/grove.test.ts
+++ b/packages/tree/tests/unit/grove.test.ts
@@ -3,7 +3,7 @@
 import BN from 'bn.js'
 import { toBN } from 'web3-utils'
 import SparseTree from 'simple-smt'
-import { DB, SQLiteConnector, schema, enableTreeCache } from '~database/node'
+import { DB, SQLiteConnector, schema } from '~database/node'
 import { Fp } from '~babyjubjub'
 import { Grove, poseidonHasher, keccakHasher, Leaf } from '~tree'
 import { utxos } from '~dataset/testset-utxos'
@@ -242,7 +242,8 @@ describe('grove full sync grove()', () => {
         withdrawals.push(withdrawal)
       }
       testTree.appendMany(withdrawals.map(w => Fp.from(w.withdrawalHash)))
-      enableTreeCache()
+      testGrove.treeCache.enable()
+      testGrove.treeCache.clear()
       const fill = Array(32 - withdrawals.length)
         .fill(null)
         .map(() => ({ hash: new BN('0') }))

--- a/packages/tree/tests/unit/light-rollup-tree-test.ts
+++ b/packages/tree/tests/unit/light-rollup-tree-test.ts
@@ -7,7 +7,8 @@ import assert from 'assert'
 import { LightRollUpTree } from '../../src/light-rollup-tree'
 import { genesisRoot, poseidonHasher } from '../../src/hasher'
 import sample from '~tree/sample'
-import { DB, TreeCache } from '~database'
+import { DB } from '~database'
+import { TreeCache } from '../../src/utils'
 
 class TestTree extends LightRollUpTree<Fp> {
   // eslint-disable-next-line class-methods-use-this

--- a/packages/tree/tests/unit/light-rollup-tree-test.ts
+++ b/packages/tree/tests/unit/light-rollup-tree-test.ts
@@ -7,7 +7,7 @@ import assert from 'assert'
 import { LightRollUpTree } from '../../src/light-rollup-tree'
 import { genesisRoot, poseidonHasher } from '../../src/hasher'
 import sample from '~tree/sample'
-import { DB } from '~database'
+import { DB, TreeCache } from '~database'
 
 class TestTree extends LightRollUpTree<Fp> {
   // eslint-disable-next-line class-methods-use-this
@@ -43,6 +43,7 @@ describe('rollup tree unit test', () => {
         forceUpdate: true,
         fullSync: true,
       },
+      treeCache: new TreeCache(),
     })
   })
   afterEach(async () => {

--- a/packages/tree/tests/unit/nullifier-tree.test.ts
+++ b/packages/tree/tests/unit/nullifier-tree.test.ts
@@ -3,7 +3,7 @@
 /* eslint-disable jest/no-hooks */
 import { toBN } from 'web3-utils'
 import BN from 'bn.js'
-import { DB, SQLiteConnector, schema } from '~database/node'
+import { DB, SQLiteConnector, schema, TreeCache } from '~database/node'
 import { NullifierTree, keccakHasher, genesisRoot } from '../../src'
 
 describe('nullifier tree unit test', () => {
@@ -17,6 +17,7 @@ describe('nullifier tree unit test', () => {
       db: mockup,
       hasher,
       depth,
+      treeCache: new TreeCache(),
     })
   })
   afterAll(async () => {

--- a/packages/tree/tests/unit/nullifier-tree.test.ts
+++ b/packages/tree/tests/unit/nullifier-tree.test.ts
@@ -3,8 +3,8 @@
 /* eslint-disable jest/no-hooks */
 import { toBN } from 'web3-utils'
 import BN from 'bn.js'
-import { DB, SQLiteConnector, schema, TreeCache } from '~database/node'
-import { NullifierTree, keccakHasher, genesisRoot } from '../../src'
+import { DB, SQLiteConnector, schema } from '~database/node'
+import { TreeCache, NullifierTree, keccakHasher, genesisRoot } from '../../src'
 
 describe('nullifier tree unit test', () => {
   let nullifierTree: NullifierTree

--- a/packages/tree/tests/unit/withdrawal-tree.test.ts
+++ b/packages/tree/tests/unit/withdrawal-tree.test.ts
@@ -3,13 +3,7 @@
 import BN from 'bn.js'
 import { toBN } from 'web3-utils'
 import { Fp } from '~babyjubjub'
-import {
-  DB,
-  TreeSpecies,
-  SQLiteConnector,
-  schema,
-  TreeCache,
-} from '~database/node'
+import { DB, TreeSpecies, SQLiteConnector, schema } from '~database/node'
 import {
   WithdrawalTree,
   TreeConfig,
@@ -17,6 +11,7 @@ import {
   Leaf,
   genesisRoot,
   verifyProof,
+  TreeCache,
 } from '~tree'
 import { utxos } from '~dataset/testset-utxos'
 import { address } from '~dataset/testset-predefined'

--- a/packages/tree/tests/unit/withdrawal-tree.test.ts
+++ b/packages/tree/tests/unit/withdrawal-tree.test.ts
@@ -3,7 +3,13 @@
 import BN from 'bn.js'
 import { toBN } from 'web3-utils'
 import { Fp } from '~babyjubjub'
-import { DB, TreeSpecies, SQLiteConnector, schema } from '~database/node'
+import {
+  DB,
+  TreeSpecies,
+  SQLiteConnector,
+  schema,
+  TreeCache,
+} from '~database/node'
 import {
   WithdrawalTree,
   TreeConfig,
@@ -44,6 +50,7 @@ describe('withdrawal tree unit test', () => {
       metadata: withdrawalTreeMetadata,
       data: withdrawalTreeInitialData,
       config: withdrawalTreeConfig,
+      treeCache: new TreeCache(),
     })
     await withdrawalTree.init()
   })


### PR DESCRIPTION
The global tree cache is causing multiple nodes in a single process to modify each others data. This is fixed by creating tree cache instances for each grove instance.

Moves tree cache from `database` package to `tree` package.

Closes #271 