### PR TITLE
Pending transaction crash fix

### DIFF
--- a/packages/coordinator/src/tx-pool.ts
+++ b/packages/coordinator/src/tx-pool.ts
@@ -96,7 +96,16 @@ export class TxMemPool implements TxPoolInterface {
         outflow: tx.outflow.map(({ note, outflowType, data }) => ({
           note: Fp.from(note),
           outflowType: Fp.from(outflowType),
-          data: data ? Fp.from(data) : undefined,
+          data: data
+            ? {
+                to: Fp.from(data.to),
+                eth: Fp.from(data.eth),
+                tokenAddr: Fp.from(data.tokenAddr),
+                erc20Amount: Fp.from(data.erc20Amount),
+                nft: Fp.from(data.nft),
+                fee: Fp.from(data.fee),
+              }
+            : undefined,
         })),
         fee: Fp.from(tx.fee),
         proof: {


### PR DESCRIPTION
`data` should be [outflow public data](https://github.com/zkopru-network/zkopru/blob/develop/packages/transaction/src/zk-tx.ts#L20). Strings need to be converted to `BN/Fp` number types.

Closes #276 