### PR TITLE
Fix rollup out of range issue

### DIFF
--- a/packages/tree/src/light-rollup-tree.ts
+++ b/packages/tree/src/light-rollup-tree.ts
@@ -408,10 +408,6 @@ export abstract class LightRollUpTree<T extends Fp | BN> {
     this.metadata.end = end
     // Update database
     // update rollup snapshot
-    const rollUpSync = {
-      start: '0',
-      end: end.toString(10),
-    }
     const rollUpSnapshot = {
       root: root instanceof Fp ? root.toUint256().toString() : hexify(root),
       index: end.toString(10),
@@ -420,17 +416,15 @@ export abstract class LightRollUpTree<T extends Fp | BN> {
           sib instanceof Fp ? sib.toUint256().toString() : hexify(sib),
         ),
       ),
+      end: end.toString(10),
     }
     db.upsert('LightTree', {
       where: { species: this.species },
-      update: {
-        ...rollUpSync,
-        ...rollUpSnapshot,
-      },
+      update: rollUpSnapshot,
       create: {
-        ...rollUpSync,
         ...rollUpSnapshot,
         species: this.species,
+        start: '0',
       },
       constraintKey: 'species',
     })

--- a/packages/tree/src/light-rollup-tree.ts
+++ b/packages/tree/src/light-rollup-tree.ts
@@ -409,7 +409,6 @@ export abstract class LightRollUpTree<T extends Fp | BN> {
     // Update database
     // update rollup snapshot
     const rollUpSync = {
-      start: start.toString(10),
       end: end.toString(10),
     }
     const rollUpSnapshot = {

--- a/packages/tree/src/light-rollup-tree.ts
+++ b/packages/tree/src/light-rollup-tree.ts
@@ -409,6 +409,7 @@ export abstract class LightRollUpTree<T extends Fp | BN> {
     // Update database
     // update rollup snapshot
     const rollUpSync = {
+      start: '0',
       end: end.toString(10),
     }
     const rollUpSnapshot = {


### PR DESCRIPTION
Disables writing a new start point to the database for the light rollup tree. No `TreeNode` entries are deleted so all indexes should be accessible regardless of current index.

Closes #279 