### PR TITLE
TX history

### DIFF
--- a/packages/core/src/node/synchronizer.ts
+++ b/packages/core/src/node/synchronizer.ts
@@ -473,6 +473,31 @@ export class Synchronizer extends EventEmitter {
           blockNumber,
           event.blockHash,
         )
+        try {
+          // try to load the transaction sender
+          const tx = await this.l1Contract.web3.eth.getTransaction(
+            event.transactionHash,
+          )
+          await this.blockCache.updateCache(
+            'Deposit',
+            {
+              where: {
+                note: note
+                  .hash()
+                  .toUint256()
+                  .toString(),
+              },
+              update: {
+                from: tx.from,
+              },
+            },
+            blockNumber,
+            event.blockHash,
+          )
+        } catch (err) {
+          logger.info(err)
+          logger.erro('core/synchronizer - Error loading deposit transaction')
+        }
         if (cb) cb(utxo)
       })
       .on('changed', event => {

--- a/packages/core/src/node/synchronizer.ts
+++ b/packages/core/src/node/synchronizer.ts
@@ -434,7 +434,7 @@ export class Synchronizer extends EventEmitter {
           salt: note.salt.toUint256().toString(),
           tokenAddr: note
             .tokenAddr()
-            .toUint256()
+            .toHex()
             .toString(),
           erc20Amount: note
             .erc20Amount()

--- a/packages/core/src/node/zkopru-node.ts
+++ b/packages/core/src/node/zkopru-node.ts
@@ -172,8 +172,9 @@ export class ZkopruNode {
     })
     for (const token of registry.erc20s) {
       const address = token.val
-      // eslint-disable-next-line no-continue
-      if (existingInfo.indexOf(address) !== -1) continue
+      if (existingInfo.findIndex(({ address: a }) => a === address) !== -1)
+        // eslint-disable-next-line no-continue
+        continue
       // otherwise load the token info
       const contract = Layer1.getERC20(this.layer1.web3, address)
       const [symbol, decimals] = await Promise.all([

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -228,7 +228,8 @@ export default [
       ['senderAddress', 'String', { optional: true }],
       ['receiverAddress', 'String', { optional: true }],
       ['tokenAddr', 'String', { optional: true }],
-      ['amount', 'String', { optional: true }],
+      ['erc20Amount', 'String', { optional: true }],
+      ['eth', 'String', { optional: true }],
       {
         name: 'proposal',
         relation: {

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -147,6 +147,15 @@ export default [
       ['verified', 'Bool', { optional: true }],
       ['isUncle', 'Bool', { optional: true }],
       {
+        name: 'header',
+        type: 'Object',
+        relation: {
+          localField: 'hash',
+          foreignField: 'hash',
+          foreignTable: 'Header',
+        },
+      },
+      {
         name: 'block',
         type: 'Object',
         optional: true,
@@ -285,6 +294,15 @@ export default [
       ['queuedAt', 'String'],
       ['ownerAddress', 'String', { optional: true }],
       ['includedIn', 'String', { optional: true }],
+      ['from', 'String', { optional: true }],
+      {
+        name: 'utxo',
+        relation: {
+          localField: 'note',
+          foreignField: 'hash',
+          foreignTable: 'Utxo',
+        },
+      },
       {
         name: 'proposal',
         relation: {

--- a/packages/database/src/schema.types.ts
+++ b/packages/database/src/schema.types.ts
@@ -79,6 +79,7 @@ export type Proposal = {
   finalized?: boolean | null
   verified?: boolean | null
   isUncle?: boolean | null
+  header?: Object | null
   block?: Object | null
 }
 
@@ -147,6 +148,8 @@ export type Deposit = {
   queuedAt: string
   ownerAddress?: string | null
   includedIn?: string | null
+  from?: string | null
+  utxo?: Object | null
   proposal?: Object | null
 }
 

--- a/packages/database/src/schema.types.ts
+++ b/packages/database/src/schema.types.ts
@@ -110,7 +110,8 @@ export type Tx = {
   senderAddress?: string | null
   receiverAddress?: string | null
   tokenAddr?: string | null
-  amount?: string | null
+  erc20Amount?: string | null
+  eth?: string | null
   proposal?: Object | null
 }
 


### PR DESCRIPTION
Improved transaction history calculation. The original implementation worked but because of the nullifier bug I refactored to a broken version. This PR puts back the logic of "if we know the nullifiers before processing the block we're the sender".

Refactors how amounts are stored to use both `erc20Amount` and `eth`.