### PR TITLE
fix: update openzeppelin dependency

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@zkopru/utils": "file:../utils",
-    "@openzeppelin/contracts": "3.4.1",
+    "@openzeppelin/contracts": "3.4.2",
     "bn.js": "^5.2.0",
     "ganache-time-traveler": "^1.0.15",
     "soltypes": "^1.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2382,10 +2382,10 @@
   dependencies:
     "@octokit/openapi-types" "^9.3.0"
 
-"@openzeppelin/contracts@3.4.1":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1.tgz#03c891fec7f93be0ae44ed74e57a122a38732ce7"
-  integrity sha512-cUriqMauq1ylzP2TxePNdPqkwI7Le3Annh4K9rrpvKfSBB/bdW+Iu1ihBaTIABTAAJ85LmKL5SSPPL9ry8d1gQ==
+"@openzeppelin/contracts@3.4.2":
+  version "3.4.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.2.tgz#d81f786fda2871d1eb8a8c5a73e455753ba53527"
+  integrity sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -3601,10 +3601,10 @@
 "@zkopru/account@file:packages/account":
   version "1.0.0-beta.2"
   dependencies:
-    "@zkopru/babyjubjub" "file:../../.cache/yarn/v6/npm-@zkopru-account-1.0.0-beta.2-b2634a47-86b7-4ed9-80f2-befe09627116-1630260733922/node_modules/@zkopru/babyjubjub"
-    "@zkopru/database" "file:../../.cache/yarn/v6/npm-@zkopru-account-1.0.0-beta.2-b2634a47-86b7-4ed9-80f2-befe09627116-1630260733922/node_modules/@zkopru/database"
-    "@zkopru/transaction" "file:../../.cache/yarn/v6/npm-@zkopru-account-1.0.0-beta.2-b2634a47-86b7-4ed9-80f2-befe09627116-1630260733922/node_modules/@zkopru/transaction"
-    "@zkopru/utils" "file:../../.cache/yarn/v6/npm-@zkopru-account-1.0.0-beta.2-b2634a47-86b7-4ed9-80f2-befe09627116-1630260733922/node_modules/@zkopru/utils"
+    "@zkopru/babyjubjub" "file:../../../.cache/yarn/v6/npm-@zkopru-account-1.0.0-beta.2-2a03025e-58da-48bc-999e-518ff17f05ed-1634704918631/node_modules/@zkopru/babyjubjub"
+    "@zkopru/database" "file:../../../.cache/yarn/v6/npm-@zkopru-account-1.0.0-beta.2-2a03025e-58da-48bc-999e-518ff17f05ed-1634704918631/node_modules/@zkopru/database"
+    "@zkopru/transaction" "file:../../../.cache/yarn/v6/npm-@zkopru-account-1.0.0-beta.2-2a03025e-58da-48bc-999e-518ff17f05ed-1634704918631/node_modules/@zkopru/transaction"
+    "@zkopru/utils" "file:../../../.cache/yarn/v6/npm-@zkopru-account-1.0.0-beta.2-2a03025e-58da-48bc-999e-518ff17f05ed-1634704918631/node_modules/@zkopru/utils"
     bip39 "^3.0.2"
     circomlib "0.5.1"
     hdkey "^1.1.1"
@@ -3618,7 +3618,7 @@
 "@zkopru/babyjubjub@file:packages/babyjubjub":
   version "1.0.0-beta.2"
   dependencies:
-    "@zkopru/utils" "file:../../.cache/yarn/v6/npm-@zkopru-babyjubjub-1.0.0-beta.2-a8e787e7-5303-4c6d-92f0-c59ddbe426df-1630260733919/node_modules/@zkopru/utils"
+    "@zkopru/utils" "file:../../../.cache/yarn/v6/npm-@zkopru-babyjubjub-1.0.0-beta.2-b701b958-d723-4c1c-8295-9d2b420d03fa-1634704918628/node_modules/@zkopru/utils"
     big-integer "^1.6.48"
     blake-hash "^1.1.0"
     bn.js "^5.2.0"
@@ -3630,15 +3630,15 @@
 "@zkopru/cli@file:packages/cli":
   version "1.0.0-beta.2"
   dependencies:
-    "@zkopru/account" "file:../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-5872bfdd-3e93-4266-aacf-f013c35ab19c-1630260733937/node_modules/@zkopru/account"
-    "@zkopru/babyjubjub" "file:../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-5872bfdd-3e93-4266-aacf-f013c35ab19c-1630260733937/node_modules/@zkopru/babyjubjub"
-    "@zkopru/contracts" "file:../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-5872bfdd-3e93-4266-aacf-f013c35ab19c-1630260733937/node_modules/@zkopru/contracts"
-    "@zkopru/coordinator" "file:../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-5872bfdd-3e93-4266-aacf-f013c35ab19c-1630260733937/node_modules/@zkopru/coordinator"
-    "@zkopru/core" "file:../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-5872bfdd-3e93-4266-aacf-f013c35ab19c-1630260733937/node_modules/@zkopru/core"
-    "@zkopru/database" "file:../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-5872bfdd-3e93-4266-aacf-f013c35ab19c-1630260733937/node_modules/@zkopru/database"
-    "@zkopru/transaction" "file:../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-5872bfdd-3e93-4266-aacf-f013c35ab19c-1630260733937/node_modules/@zkopru/transaction"
-    "@zkopru/utils" "file:../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-5872bfdd-3e93-4266-aacf-f013c35ab19c-1630260733937/node_modules/@zkopru/utils"
-    "@zkopru/zk-wizard" "file:../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-5872bfdd-3e93-4266-aacf-f013c35ab19c-1630260733937/node_modules/@zkopru/zk-wizard"
+    "@zkopru/account" "file:../../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-cb78c0aa-16c0-4408-b59e-8b6e19571bea-1634704918650/node_modules/@zkopru/account"
+    "@zkopru/babyjubjub" "file:../../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-cb78c0aa-16c0-4408-b59e-8b6e19571bea-1634704918650/node_modules/@zkopru/babyjubjub"
+    "@zkopru/contracts" "file:../../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-cb78c0aa-16c0-4408-b59e-8b6e19571bea-1634704918650/node_modules/@zkopru/contracts"
+    "@zkopru/coordinator" "file:../../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-cb78c0aa-16c0-4408-b59e-8b6e19571bea-1634704918650/node_modules/@zkopru/coordinator"
+    "@zkopru/core" "file:../../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-cb78c0aa-16c0-4408-b59e-8b6e19571bea-1634704918650/node_modules/@zkopru/core"
+    "@zkopru/database" "file:../../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-cb78c0aa-16c0-4408-b59e-8b6e19571bea-1634704918650/node_modules/@zkopru/database"
+    "@zkopru/transaction" "file:../../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-cb78c0aa-16c0-4408-b59e-8b6e19571bea-1634704918650/node_modules/@zkopru/transaction"
+    "@zkopru/utils" "file:../../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-cb78c0aa-16c0-4408-b59e-8b6e19571bea-1634704918650/node_modules/@zkopru/utils"
+    "@zkopru/zk-wizard" "file:../../../.cache/yarn/v6/npm-@zkopru-cli-1.0.0-beta.2-cb78c0aa-16c0-4408-b59e-8b6e19571bea-1634704918650/node_modules/@zkopru/zk-wizard"
     axios "^0.21.1"
     big-integer "^1.6.48"
     bip39 "^3.0.2"
@@ -3663,8 +3663,8 @@
   version "1.0.0-beta.2"
   dependencies:
     "@ethereumjs/tx" "3.2.0"
-    "@openzeppelin/contracts" "3.4.1"
-    "@zkopru/utils" "file:../../.cache/yarn/v6/npm-@zkopru-contracts-1.0.0-beta.2-25ea1ff0-4669-42fc-9fd5-a82c89f639a6-1630260733924/node_modules/@zkopru/utils"
+    "@openzeppelin/contracts" "3.4.2"
+    "@zkopru/utils" "file:../../../.cache/yarn/v6/npm-@zkopru-contracts-1.0.0-beta.2-b92afddd-d160-40c3-8e8d-b11982f96c3d-1634704918633/node_modules/@zkopru/utils"
     bn.js "^5.2.0"
     ganache-time-traveler "^1.0.15"
     soltypes "^1.3.5"
@@ -3675,13 +3675,13 @@
 "@zkopru/coordinator@file:packages/coordinator":
   version "1.0.0-beta.2"
   dependencies:
-    "@zkopru/babyjubjub" "file:../../.cache/yarn/v6/npm-@zkopru-coordinator-1.0.0-beta.2-bbeeb35e-2cd6-4f24-829b-ed315d625a3f-1630260733926/node_modules/@zkopru/babyjubjub"
-    "@zkopru/contracts" "file:../../.cache/yarn/v6/npm-@zkopru-coordinator-1.0.0-beta.2-bbeeb35e-2cd6-4f24-829b-ed315d625a3f-1630260733926/node_modules/@zkopru/contracts"
-    "@zkopru/core" "file:../../.cache/yarn/v6/npm-@zkopru-coordinator-1.0.0-beta.2-bbeeb35e-2cd6-4f24-829b-ed315d625a3f-1630260733926/node_modules/@zkopru/core"
-    "@zkopru/database" "file:../../.cache/yarn/v6/npm-@zkopru-coordinator-1.0.0-beta.2-bbeeb35e-2cd6-4f24-829b-ed315d625a3f-1630260733926/node_modules/@zkopru/database"
-    "@zkopru/transaction" "file:../../.cache/yarn/v6/npm-@zkopru-coordinator-1.0.0-beta.2-bbeeb35e-2cd6-4f24-829b-ed315d625a3f-1630260733926/node_modules/@zkopru/transaction"
-    "@zkopru/tree" "file:../../.cache/yarn/v6/npm-@zkopru-coordinator-1.0.0-beta.2-bbeeb35e-2cd6-4f24-829b-ed315d625a3f-1630260733926/node_modules/@zkopru/tree"
-    "@zkopru/utils" "file:../../.cache/yarn/v6/npm-@zkopru-coordinator-1.0.0-beta.2-bbeeb35e-2cd6-4f24-829b-ed315d625a3f-1630260733926/node_modules/@zkopru/utils"
+    "@zkopru/babyjubjub" "file:../../../.cache/yarn/v6/npm-@zkopru-coordinator-1.0.0-beta.2-ebb24503-b290-4bed-bb5d-9ae8d9afe5ca-1634704918634/node_modules/@zkopru/babyjubjub"
+    "@zkopru/contracts" "file:../../../.cache/yarn/v6/npm-@zkopru-coordinator-1.0.0-beta.2-ebb24503-b290-4bed-bb5d-9ae8d9afe5ca-1634704918634/node_modules/@zkopru/contracts"
+    "@zkopru/core" "file:../../../.cache/yarn/v6/npm-@zkopru-coordinator-1.0.0-beta.2-ebb24503-b290-4bed-bb5d-9ae8d9afe5ca-1634704918634/node_modules/@zkopru/core"
+    "@zkopru/database" "file:../../../.cache/yarn/v6/npm-@zkopru-coordinator-1.0.0-beta.2-ebb24503-b290-4bed-bb5d-9ae8d9afe5ca-1634704918634/node_modules/@zkopru/database"
+    "@zkopru/transaction" "file:../../../.cache/yarn/v6/npm-@zkopru-coordinator-1.0.0-beta.2-ebb24503-b290-4bed-bb5d-9ae8d9afe5ca-1634704918634/node_modules/@zkopru/transaction"
+    "@zkopru/tree" "file:../../../.cache/yarn/v6/npm-@zkopru-coordinator-1.0.0-beta.2-ebb24503-b290-4bed-bb5d-9ae8d9afe5ca-1634704918634/node_modules/@zkopru/tree"
+    "@zkopru/utils" "file:../../../.cache/yarn/v6/npm-@zkopru-coordinator-1.0.0-beta.2-ebb24503-b290-4bed-bb5d-9ae8d9afe5ca-1634704918634/node_modules/@zkopru/utils"
     async-lock "^1.2.2"
     axios "^0.21.1"
     big-integer "^1.6.48"
@@ -3709,13 +3709,13 @@
 "@zkopru/core@file:packages/core":
   version "1.0.0-beta.2"
   dependencies:
-    "@zkopru/account" "file:../../.cache/yarn/v6/npm-@zkopru-core-1.0.0-beta.2-e5bc3ad6-e396-44b8-9651-c1ecfff8d414-1630260733925/node_modules/@zkopru/account"
-    "@zkopru/babyjubjub" "file:../../.cache/yarn/v6/npm-@zkopru-core-1.0.0-beta.2-e5bc3ad6-e396-44b8-9651-c1ecfff8d414-1630260733925/node_modules/@zkopru/babyjubjub"
-    "@zkopru/contracts" "file:../../.cache/yarn/v6/npm-@zkopru-core-1.0.0-beta.2-e5bc3ad6-e396-44b8-9651-c1ecfff8d414-1630260733925/node_modules/@zkopru/contracts"
-    "@zkopru/database" "file:../../.cache/yarn/v6/npm-@zkopru-core-1.0.0-beta.2-e5bc3ad6-e396-44b8-9651-c1ecfff8d414-1630260733925/node_modules/@zkopru/database"
-    "@zkopru/transaction" "file:../../.cache/yarn/v6/npm-@zkopru-core-1.0.0-beta.2-e5bc3ad6-e396-44b8-9651-c1ecfff8d414-1630260733925/node_modules/@zkopru/transaction"
-    "@zkopru/tree" "file:../../.cache/yarn/v6/npm-@zkopru-core-1.0.0-beta.2-e5bc3ad6-e396-44b8-9651-c1ecfff8d414-1630260733925/node_modules/@zkopru/tree"
-    "@zkopru/utils" "file:../../.cache/yarn/v6/npm-@zkopru-core-1.0.0-beta.2-e5bc3ad6-e396-44b8-9651-c1ecfff8d414-1630260733925/node_modules/@zkopru/utils"
+    "@zkopru/account" "file:../../../.cache/yarn/v6/npm-@zkopru-core-1.0.0-beta.2-213e190e-ce85-4431-80a9-56bf77adc290-1634704918640/node_modules/@zkopru/account"
+    "@zkopru/babyjubjub" "file:../../../.cache/yarn/v6/npm-@zkopru-core-1.0.0-beta.2-213e190e-ce85-4431-80a9-56bf77adc290-1634704918640/node_modules/@zkopru/babyjubjub"
+    "@zkopru/contracts" "file:../../../.cache/yarn/v6/npm-@zkopru-core-1.0.0-beta.2-213e190e-ce85-4431-80a9-56bf77adc290-1634704918640/node_modules/@zkopru/contracts"
+    "@zkopru/database" "file:../../../.cache/yarn/v6/npm-@zkopru-core-1.0.0-beta.2-213e190e-ce85-4431-80a9-56bf77adc290-1634704918640/node_modules/@zkopru/database"
+    "@zkopru/transaction" "file:../../../.cache/yarn/v6/npm-@zkopru-core-1.0.0-beta.2-213e190e-ce85-4431-80a9-56bf77adc290-1634704918640/node_modules/@zkopru/transaction"
+    "@zkopru/tree" "file:../../../.cache/yarn/v6/npm-@zkopru-core-1.0.0-beta.2-213e190e-ce85-4431-80a9-56bf77adc290-1634704918640/node_modules/@zkopru/tree"
+    "@zkopru/utils" "file:../../../.cache/yarn/v6/npm-@zkopru-core-1.0.0-beta.2-213e190e-ce85-4431-80a9-56bf77adc290-1634704918640/node_modules/@zkopru/utils"
     async-lock "^1.2.2"
     big-integer "^1.6.48"
     bn.js "^5.2.0"
@@ -3735,8 +3735,8 @@
 "@zkopru/database@file:packages/database":
   version "1.0.0-beta.2"
   dependencies:
-    "@zkopru/babyjubjub" "file:../../.cache/yarn/v6/npm-@zkopru-database-1.0.0-beta.2-487a72b0-254a-4a30-91d7-45041012c925-1630260733936/node_modules/@zkopru/babyjubjub"
-    "@zkopru/utils" "file:../../.cache/yarn/v6/npm-@zkopru-database-1.0.0-beta.2-487a72b0-254a-4a30-91d7-45041012c925-1630260733936/node_modules/@zkopru/utils"
+    "@zkopru/babyjubjub" "file:../../../.cache/yarn/v6/npm-@zkopru-database-1.0.0-beta.2-176d8f21-180e-4306-b2c4-0bf4e72e695d-1634704918648/node_modules/@zkopru/babyjubjub"
+    "@zkopru/utils" "file:../../../.cache/yarn/v6/npm-@zkopru-database-1.0.0-beta.2-176d8f21-180e-4306-b2c4-0bf4e72e695d-1634704918648/node_modules/@zkopru/utils"
     async-lock "^1.2.11"
     bn.js "^5.2.0"
     fake-indexeddb "^3.1.2"
@@ -3751,8 +3751,8 @@
 "@zkopru/transaction@file:packages/transaction":
   version "1.0.0-beta.2"
   dependencies:
-    "@zkopru/babyjubjub" "file:../../.cache/yarn/v6/npm-@zkopru-transaction-1.0.0-beta.2-702c9ff9-5e26-454d-8146-efa5a0a55213-1630260733920/node_modules/@zkopru/babyjubjub"
-    "@zkopru/utils" "file:../../.cache/yarn/v6/npm-@zkopru-transaction-1.0.0-beta.2-702c9ff9-5e26-454d-8146-efa5a0a55213-1630260733920/node_modules/@zkopru/utils"
+    "@zkopru/babyjubjub" "file:../../../.cache/yarn/v6/npm-@zkopru-transaction-1.0.0-beta.2-9f3eba6b-306c-4048-af1f-087da90a7a95-1634704918630/node_modules/@zkopru/babyjubjub"
+    "@zkopru/utils" "file:../../../.cache/yarn/v6/npm-@zkopru-transaction-1.0.0-beta.2-9f3eba6b-306c-4048-af1f-087da90a7a95-1634704918630/node_modules/@zkopru/utils"
     big-integer "^1.6.48"
     bs58 "^4.0.1"
     chacha20 "^0.1.4"
@@ -3766,10 +3766,10 @@
 "@zkopru/tree@file:packages/tree":
   version "1.0.0-beta.2"
   dependencies:
-    "@zkopru/babyjubjub" "file:../../.cache/yarn/v6/npm-@zkopru-tree-1.0.0-beta.2-b1346ef1-4ba7-466f-ae1a-6e56d367d718-1630260733930/node_modules/@zkopru/babyjubjub"
-    "@zkopru/database" "file:../../.cache/yarn/v6/npm-@zkopru-tree-1.0.0-beta.2-b1346ef1-4ba7-466f-ae1a-6e56d367d718-1630260733930/node_modules/@zkopru/database"
-    "@zkopru/transaction" "file:../../.cache/yarn/v6/npm-@zkopru-tree-1.0.0-beta.2-b1346ef1-4ba7-466f-ae1a-6e56d367d718-1630260733930/node_modules/@zkopru/transaction"
-    "@zkopru/utils" "file:../../.cache/yarn/v6/npm-@zkopru-tree-1.0.0-beta.2-b1346ef1-4ba7-466f-ae1a-6e56d367d718-1630260733930/node_modules/@zkopru/utils"
+    "@zkopru/babyjubjub" "file:../../../.cache/yarn/v6/npm-@zkopru-tree-1.0.0-beta.2-5205b00b-1afd-402a-b4c1-7dde7d75873a-1634704918642/node_modules/@zkopru/babyjubjub"
+    "@zkopru/database" "file:../../../.cache/yarn/v6/npm-@zkopru-tree-1.0.0-beta.2-5205b00b-1afd-402a-b4c1-7dde7d75873a-1634704918642/node_modules/@zkopru/database"
+    "@zkopru/transaction" "file:../../../.cache/yarn/v6/npm-@zkopru-tree-1.0.0-beta.2-5205b00b-1afd-402a-b4c1-7dde7d75873a-1634704918642/node_modules/@zkopru/transaction"
+    "@zkopru/utils" "file:../../../.cache/yarn/v6/npm-@zkopru-tree-1.0.0-beta.2-5205b00b-1afd-402a-b4c1-7dde7d75873a-1634704918642/node_modules/@zkopru/utils"
     async-lock "^1.2.2"
     big-integer "^1.6.48"
     bn.js "^5.2.0"
@@ -3806,14 +3806,14 @@
 "@zkopru/zk-wizard@file:packages/zk-wizard":
   version "1.0.0-beta.2"
   dependencies:
-    "@zkopru/account" "file:../../.cache/yarn/v6/npm-@zkopru-zk-wizard-1.0.0-beta.2-be8cb0fd-9a81-4207-b5ac-2f3fbf21f385-1630260733931/node_modules/@zkopru/account"
-    "@zkopru/babyjubjub" "file:../../.cache/yarn/v6/npm-@zkopru-zk-wizard-1.0.0-beta.2-be8cb0fd-9a81-4207-b5ac-2f3fbf21f385-1630260733931/node_modules/@zkopru/babyjubjub"
-    "@zkopru/contracts" "file:../../.cache/yarn/v6/npm-@zkopru-zk-wizard-1.0.0-beta.2-be8cb0fd-9a81-4207-b5ac-2f3fbf21f385-1630260733931/node_modules/@zkopru/contracts"
-    "@zkopru/core" "file:../../.cache/yarn/v6/npm-@zkopru-zk-wizard-1.0.0-beta.2-be8cb0fd-9a81-4207-b5ac-2f3fbf21f385-1630260733931/node_modules/@zkopru/core"
-    "@zkopru/database" "file:../../.cache/yarn/v6/npm-@zkopru-zk-wizard-1.0.0-beta.2-be8cb0fd-9a81-4207-b5ac-2f3fbf21f385-1630260733931/node_modules/@zkopru/database"
-    "@zkopru/transaction" "file:../../.cache/yarn/v6/npm-@zkopru-zk-wizard-1.0.0-beta.2-be8cb0fd-9a81-4207-b5ac-2f3fbf21f385-1630260733931/node_modules/@zkopru/transaction"
-    "@zkopru/tree" "file:../../.cache/yarn/v6/npm-@zkopru-zk-wizard-1.0.0-beta.2-be8cb0fd-9a81-4207-b5ac-2f3fbf21f385-1630260733931/node_modules/@zkopru/tree"
-    "@zkopru/utils" "file:../../.cache/yarn/v6/npm-@zkopru-zk-wizard-1.0.0-beta.2-be8cb0fd-9a81-4207-b5ac-2f3fbf21f385-1630260733931/node_modules/@zkopru/utils"
+    "@zkopru/account" "file:../../../.cache/yarn/v6/npm-@zkopru-zk-wizard-1.0.0-beta.2-7046e1fa-32ff-4f12-a6b8-848dc12f474f-1634704918638/node_modules/@zkopru/account"
+    "@zkopru/babyjubjub" "file:../../../.cache/yarn/v6/npm-@zkopru-zk-wizard-1.0.0-beta.2-7046e1fa-32ff-4f12-a6b8-848dc12f474f-1634704918638/node_modules/@zkopru/babyjubjub"
+    "@zkopru/contracts" "file:../../../.cache/yarn/v6/npm-@zkopru-zk-wizard-1.0.0-beta.2-7046e1fa-32ff-4f12-a6b8-848dc12f474f-1634704918638/node_modules/@zkopru/contracts"
+    "@zkopru/core" "file:../../../.cache/yarn/v6/npm-@zkopru-zk-wizard-1.0.0-beta.2-7046e1fa-32ff-4f12-a6b8-848dc12f474f-1634704918638/node_modules/@zkopru/core"
+    "@zkopru/database" "file:../../../.cache/yarn/v6/npm-@zkopru-zk-wizard-1.0.0-beta.2-7046e1fa-32ff-4f12-a6b8-848dc12f474f-1634704918638/node_modules/@zkopru/database"
+    "@zkopru/transaction" "file:../../../.cache/yarn/v6/npm-@zkopru-zk-wizard-1.0.0-beta.2-7046e1fa-32ff-4f12-a6b8-848dc12f474f-1634704918638/node_modules/@zkopru/transaction"
+    "@zkopru/tree" "file:../../../.cache/yarn/v6/npm-@zkopru-zk-wizard-1.0.0-beta.2-7046e1fa-32ff-4f12-a6b8-848dc12f474f-1634704918638/node_modules/@zkopru/tree"
+    "@zkopru/utils" "file:../../../.cache/yarn/v6/npm-@zkopru-zk-wizard-1.0.0-beta.2-7046e1fa-32ff-4f12-a6b8-848dc12f474f-1634704918638/node_modules/@zkopru/utils"
     big-integer "^1.6.48"
     circom_runtime "0.1.13"
     eth-sig-util "^3.0.1"
@@ -12499,7 +12499,7 @@ lodash@4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
-lodash@4.17.21, lodash@^4.1.0, lodash@^4.14.2, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.7.0:
+lodash@4.17.21, lodash@^4.1.0, lodash@^4.14.2, lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
Low severity issue for Zkopru since we aren't using Timelock for any protocol logic. To avoid any future risk, this patch updates the openzeppelin library version from 3.4.1 to 3.4.2.