### PR TITLE
fix: proper null handling in ne expressions for indexeddb

### DIFF
--- a/packages/database/src/helpers/memory.ts
+++ b/packages/database/src/helpers/memory.ts
@@ -67,6 +67,9 @@ export function validateDocuments(table: SchemaTable, _docs: any | any[]) {
 function _matchDocument(where: WhereClause, doc: any) {
   for (const [key, val] of Object.entries(where)) {
     if (typeof val === 'object' && !Array.isArray(val) && val !== null) {
+      if (val.ne === null && (doc[key] === null || doc[key] === undefined)) {
+        return false
+      }
       if (typeof val.ne !== 'undefined' && doc[key] === val.ne) {
         return false
       }
@@ -86,6 +89,7 @@ function _matchDocument(where: WhereClause, doc: any) {
         if (!Array.isArray(val.nin))
           throw new Error('Invalid nin value provided, must be array')
         for (const v of val.nin) {
+          if (doc[key] === null && (v === null || v === undefined)) return false
           if (doc[key] === v) return false
         }
       }

--- a/packages/database/tests/database/find.ts
+++ b/packages/database/tests/database/find.ts
@@ -424,4 +424,33 @@ export default function(this: { db: DB }) {
       assert.equal(docs.length, 2)
     }
   })
+
+  test('should find null field only', async () => {
+    const table = 'TableThree'
+    await this.db.create(table, {
+      id: 'test1',
+    })
+    await this.db.create(table, {
+      id: 'test2',
+      optionalField: 'not null',
+    })
+    {
+      const docs = await this.db.findMany(table, {
+        where: {
+          optionalField: null,
+        },
+      })
+      assert.equal(docs.length, 1, 'eq failed')
+      assert(!docs[0].optionalField, 'eq incorrect')
+    }
+    {
+      const docs = await this.db.findMany(table, {
+        where: {
+          optionalField: { ne: null },
+        },
+      })
+      assert.equal(docs.length, 1, 'ne failed')
+      assert(!!docs[0].optionalField, 'ne incorect')
+    }
+  })
 }


### PR DESCRIPTION
Fixes a bug that caused the `ne` operator to fail to work with `null` values. e.g. documents with non-null fields would be returned.