### PR TITLE
Pending support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
 
 ![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/zkopru-network/zkopru)
 
-An audit for the Zkopru testnet v2 is on the process!
-
-| Branch    | Status                                                                                                                                                         |
-| --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `develop` | [![zkopru-network](https://circleci.com/gh/zkopru-network/zkopru/tree/develop.svg?style=svg)](https://app.circleci.com/pipelines/github/zkopru-network/zkopru) |
+| Branch    | Status                                                                                                                                                                        |
+| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `main`    | [![zkopru-network](https://circleci.com/gh/zkopru-network/zkopru/tree/main.svg?style=svg)](https://app.circleci.com/pipelines/github/zkopru-network/zkopru?branch=main)       |
+| `develop` | [![zkopru-network](https://circleci.com/gh/zkopru-network/zkopru/tree/develop.svg?style=svg)](https://app.circleci.com/pipelines/github/zkopru-network/zkopru?branch=develop) |
 
 ![Banner](https://docs.google.com/drawings/d/e/2PACX-1vRwGTvmJAbNBZCK5syubcrWZgYc3wuK9cHZScbc5lgyLbBYsx42Xzo60unw4-oLlPg_-nwXxaE3t9c6/pub?w=1280)
 
@@ -14,12 +13,11 @@ An audit for the Zkopru testnet v2 is on the process!
 
 Zkopru(zk-optimistic-rollup) is a layer-2 scaling solution for private transactions using zk-SNARK and optimistic rollup. It supports private transfer and private atomic swap within the layer-2 network between ETH, ERC20, ERC721 at a low cost. Also, with the pay-in-advance feature, users can withdraw assets from the layer-2 before the finalization.
 
-## Usage
+## Related projects
 
-```shell
-npm install -g @zkopru/cli
-zkopru-wallet
-```
+- [Zkopru Wallet](https://github.com/zkopru-network/wallet)
+- [Private Exchange](https://github.com/zkopru-network/private-exchange)
+- [Payment Service](https://github.com/zkopru-network/merchant-payment-service)
 
 ## Get more information
 
@@ -27,10 +25,19 @@ zkopru-wallet
 
 - [Document](https://docs.zkopru.network) [(edit)](https://github.com/wanseob/docs.zkopru.network)
 
+## Audits
+
+- [1st audit report by Least Authority](https://github.com/zkopru-network/resources/blob/main/audits/v1/Least%20Authority%20-%20Ethereum%20Foundation%20Zkopru%20zk-SNARK%20Circuits%20%2B%20Smart%20Contracts%20-%20Final%20Audit%20Report.pdf)
+- [2nd audit report by Igor Gulamov](https://github.com/zkopru-network/resources/blob/main/audits/v2/AUDIT-REPORT.md)
+
 ## Trusted Setup
 
 - [Trusted Setup Result](https://storage.googleapis.com/zkopru-mpc-files/index.html)
 - [Keys](https://ipfs.io/ipfs/QmSQtbTnt5RWrP8uWJ3S5xUKntTx2DqcM7mM5vUg9uJGxq)(ipfs cid: QmSQtbTnt5RWrP8uWJ3S5xUKntTx2DqcM7mM5vUg9uJGxq)
+
+## Stress Testing
+
+- [Go to repo](https://github.com/zkopru-network/stress-test)
 
 ## Contribution
 
@@ -53,6 +60,8 @@ zkopru-wallet
 - Thore Hildebrandt ([@ETHorHIL](https://github.com/ETHorHIL), hildebrandtthore@gmail.com)
 - Geoff Lamperd ([@glamperd](https://github.com/glamperd))
 - Jinhwan Shin ([@sifnoc](https://github.com/sifnoc))
+- Rachel Akerley ([@rachelaux](https://github.com/rachelaux))
+- Takamichi Tsutsumi ([@tkmct](https:?/github.com/tkmct))
 
 ## License
 

--- a/packages/account/src/viewer.ts
+++ b/packages/account/src/viewer.ts
@@ -36,7 +36,7 @@ export class ZkViewer {
     return this.A
   }
 
-  decrypt(zkTx: ZkTx, tokenRegistry?: TokenRegistry): Utxo[] {
+  decrypt(zkTx: ZkTx, tokenRegistry: TokenRegistry): Utxo[] {
     const tryDecodeNote = (
       bytes: Buffer,
       outflows: ZkOutflow[],

--- a/packages/client/src/zkopru-wallet.ts
+++ b/packages/client/src/zkopru-wallet.ts
@@ -277,10 +277,17 @@ export default class ZkopruWallet {
     const withdrawals = await this.wallet.db.findMany('Withdrawal', {
       where: {
         to: this.node.node?.layer1.web3.utils.toChecksumAddress(ethAddress),
+        includedIn: { ne: null },
       },
       include: {
         proposal: { header: true },
       },
+    })
+    const incompleteWithdrawals = await this.wallet.db.findMany('Withdrawal', {
+      where: {
+        to: this.node.node?.layer1.web3.utils.toChecksumAddress(ethAddress),
+        includedIn: null,
+      }
     })
     const pending = await this.wallet.db.findMany('PendingTx', {
       where: {
@@ -295,6 +302,9 @@ export default class ZkopruWallet {
         ),
         ...incompleteDeposits.map(obj =>
           Object.assign(obj, { type: 'Deposit', ...obj.utxo }),
+        ),
+        ...incompleteWithdrawals.map(obj =>
+          Object.assign(obj, { type: 'Withdraw' })
         ),
       ],
       history: [

--- a/packages/client/src/zkopru-wallet.ts
+++ b/packages/client/src/zkopru-wallet.ts
@@ -226,6 +226,7 @@ export default class ZkopruWallet {
     const sent = await this.wallet.db.findMany('Tx', {
       where: {
         senderAddress: zkAddress,
+        receiverAddress: null,
       },
       include: {
         proposal: { header: true },
@@ -234,6 +235,16 @@ export default class ZkopruWallet {
     const received = await this.wallet.db.findMany('Tx', {
       where: {
         receiverAddress: zkAddress,
+        senderAddress: null,
+      },
+      include: {
+        proposal: { header: true },
+      },
+    })
+    const self = await this.wallet.db.findMany('Tx', {
+      where: {
+        receiverAddress: zkAddress,
+        senderAddress: zkAddress,
       },
       include: {
         proposal: { header: true },
@@ -287,6 +298,7 @@ export default class ZkopruWallet {
         ),
       ],
       history: [
+        ...self.map(obj => Object.assign(obj, { type: 'Self' })),
         ...sent.map(obj => Object.assign(obj, { type: 'Send' })),
         ...received.map(obj => Object.assign(obj, { type: 'Receive' })),
         ...completeDeposits.map(obj =>

--- a/packages/client/src/zkopru-wallet.ts
+++ b/packages/client/src/zkopru-wallet.ts
@@ -287,7 +287,7 @@ export default class ZkopruWallet {
       where: {
         to: this.node.node?.layer1.web3.utils.toChecksumAddress(ethAddress),
         includedIn: null,
-      }
+      },
     })
     const pending = await this.wallet.db.findMany('PendingTx', {
       where: {
@@ -304,7 +304,7 @@ export default class ZkopruWallet {
           Object.assign(obj, { type: 'Deposit', ...obj.utxo }),
         ),
         ...incompleteWithdrawals.map(obj =>
-          Object.assign(obj, { type: 'Withdraw' })
+          Object.assign(obj, { type: 'Withdraw' }),
         ),
       ],
       history: [

--- a/packages/core/src/node/block-processor.ts
+++ b/packages/core/src/node/block-processor.ts
@@ -361,7 +361,10 @@ export class BlockProcessor extends EventEmitter {
     decryptedNotes: Utxo[],
     db: TransactionDB,
   ) {
-    const isWithdrawal = tx.outflow.findIndex(({ outflowType }) => outflowType.eqn(OutflowType.WITHDRAWAL)) !== -1
+    const isWithdrawal =
+      tx.outflow.findIndex(({ outflowType }) =>
+        outflowType.eqn(OutflowType.WITHDRAWAL),
+      ) !== -1
     if (isWithdrawal) return // we don't need to save withdrawal here
     const inflows = await this.db.findMany('Utxo', {
       where: {

--- a/packages/core/src/node/block-processor.ts
+++ b/packages/core/src/node/block-processor.ts
@@ -516,7 +516,7 @@ export class BlockProcessor extends EventEmitter {
           tokenAddr: outflow.data.tokenAddr.toAddress().toString(),
           erc20Amount: outflow.data.erc20Amount.toUint256().toString(),
           nft: outflow.data.nft.toUint256().toString(),
-          fee: outflow.data.fee.toUint256().toString(),
+          fee: tx.fee.toUint256().toString(),
           includedIn: block.hash.toString(),
         }
         db.upsert('Withdrawal', {

--- a/packages/database/src/connectors/indexed-db.ts
+++ b/packages/database/src/connectors/indexed-db.ts
@@ -35,7 +35,7 @@ export class IndexedDBConnector extends DB {
   static async create(tables: TableData[]) {
     const schema = constructSchema(tables)
     const connector = new this(schema)
-    connector.db = await openDB(DB_NAME, 16, {
+    connector.db = await openDB(DB_NAME, 17, {
       /**
        * If an index is changed (e.g. same keys different "unique" value) the
        * index will not be updated. If such a case occurs the name should be

--- a/packages/database/src/connectors/indexed-db.ts
+++ b/packages/database/src/connectors/indexed-db.ts
@@ -35,7 +35,7 @@ export class IndexedDBConnector extends DB {
   static async create(tables: TableData[]) {
     const schema = constructSchema(tables)
     const connector = new this(schema)
-    connector.db = await openDB(DB_NAME, 15, {
+    connector.db = await openDB(DB_NAME, 16, {
       /**
        * If an index is changed (e.g. same keys different "unique" value) the
        * index will not be updated. If such a case occurs the name should be

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -283,6 +283,22 @@ export default [
     ],
   },
   {
+    name: 'PendingDeposit',
+    primaryKey: 'note',
+    rows: [
+      ['note', 'String'],
+      ['fee', 'String'],
+      {
+        name: 'utxo',
+        relation: {
+          localField: 'note',
+          foreignField: 'hash',
+          foreignTable: 'Utxo',
+        },
+      },
+    ],
+  },
+  {
     name: 'Deposit',
     primaryKey: 'note',
     rows: [

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -264,7 +264,8 @@ export default [
       ['senderAddress', 'String', { optional: true }],
       ['receiverAddress', 'String', { optional: true }],
       ['tokenAddr', 'String', { optional: true }],
-      ['amount', 'String', { optional: true }],
+      ['erc20Amount', 'String', { optional: true }],
+      ['eth', 'String', { optional: true }],
     ],
   },
   {

--- a/packages/dataset/package.json
+++ b/packages/dataset/package.json
@@ -9,7 +9,8 @@
     "dist"
   ],
   "_moduleAliases": {
-    "~dataset": "dist"
+    "~dataset": "dist",
+    "~transaction": "../transaction/dist"
   },
   "scripts": {
     "prebuild": "shx mkdir -p dist",

--- a/packages/dataset/tests/index.test.ts
+++ b/packages/dataset/tests/index.test.ts
@@ -2,6 +2,7 @@
  * @jest-environment node
  */
 
+import { TokenRegistry } from '~transaction/tokens'
 import { getDummyBody } from '../src/testset-block'
 import { accounts } from '../src/testset-predefined'
 import { loadZkTxs } from '../src/testset-zktxs'
@@ -15,7 +16,8 @@ describe('index', () => {
     it('encrypt-decrypt works', async () => {
       const zktxs = await loadZkTxs()
       const tx1 = zktxs[0]
-      const note = accounts.bob.decrypt(tx1)
+      const tokenRegistry: TokenRegistry = new TokenRegistry()
+      const note = accounts.bob.decrypt(tx1, tokenRegistry)
       expect(note[0]).toBeDefined()
       expect(note[0].owner.toString()).toBe(accounts.bob.zkAddress.toString())
     }, 60000)

--- a/packages/transaction/src/utxo.ts
+++ b/packages/transaction/src/utxo.ts
@@ -113,7 +113,7 @@ export class Utxo extends Note {
     memo: Buffer
     spendingPubKey: Fp
     viewingKey: Fr
-    tokenRegistry?: TokenRegistry
+    tokenRegistry: TokenRegistry
   }): Utxo | undefined {
     const ephemeralPubKey = Point.decode(memo.subarray(0, 32))
     const sharedKey = ephemeralPubKey.mul(viewingKey).encode()
@@ -134,32 +134,30 @@ export class Utxo extends Note {
       return etherNote
     }
     // Try to find ERC20 or ERC721 notes
-    if (tokenRegistry) {
-      const erc20Addresses = tokenRegistry.getErc20Addresses(tokenIdentifier)
-      for (const tokenAddr of erc20Addresses) {
-        const erc20Note = Utxo.newERC20Note({
-          owner,
-          eth: Fp.from(0),
-          tokenAddr,
-          erc20Amount: value,
-          salt,
-        })
-        if (utxoHash.eq(erc20Note.hash())) {
-          return erc20Note
-        }
+    const erc20Addresses = tokenRegistry.getErc20Addresses(tokenIdentifier)
+    for (const tokenAddr of erc20Addresses) {
+      const erc20Note = Utxo.newERC20Note({
+        owner,
+        eth: Fp.from(0),
+        tokenAddr,
+        erc20Amount: value,
+        salt,
+      })
+      if (utxoHash.eq(erc20Note.hash())) {
+        return erc20Note
       }
-      const erc721Addresses = tokenRegistry.getErc721Addresses(tokenIdentifier)
-      for (const tokenAddr of erc721Addresses) {
-        const nftNote = Utxo.newNFTNote({
-          owner,
-          eth: Fp.from(0),
-          tokenAddr,
-          nft: value,
-          salt,
-        })
-        if (utxoHash.eq(nftNote.hash())) {
-          return nftNote
-        }
+    }
+    const erc721Addresses = tokenRegistry.getErc721Addresses(tokenIdentifier)
+    for (const tokenAddr of erc721Addresses) {
+      const nftNote = Utxo.newNFTNote({
+        owner,
+        eth: Fp.from(0),
+        tokenAddr,
+        nft: value,
+        salt,
+      })
+      if (utxoHash.eq(nftNote.hash())) {
+        return nftNote
       }
     }
     return undefined

--- a/packages/zk-wizard/src/zk-wallet-account.ts
+++ b/packages/zk-wizard/src/zk-wallet-account.ts
@@ -786,7 +786,18 @@ export class ZkWalletAccount {
         .eth()
         .add(fee)
         .toString(16),
-      onComplete: () => this.saveOutflow(note),
+      onComplete: async () => {
+        await this.db.transaction(async db => {
+          db.create('PendingDeposit', {
+            note: note
+              .hash()
+              .toUint256()
+              .toString(),
+            fee: fee.toUint256().toString(),
+          })
+          await this.saveOutflow(note, db)
+        })
+      },
     }
   }
 


### PR DESCRIPTION
Create a table called `PendingDeposit` that stores short lived references to utxo notes for a deposit. The client can access these immediately (e.g. before the deposit transaction is confirmed and events are emitted).

Fix the transaction fee stored on `Withdrawal` entries.

Fix a bug preventing withdrawals from being stored without a prepay signature.

Change the `PendingTx` schema to match that of `Tx`.