### PR TITLE
drone CI config

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,7 @@ steps:
   image: plugins/downstream
   fork: true
   settings:
-    server: https://zkopru.sifnoc.net
+    server: https://drone.zkopru.network
     token:
       from_secret: drone_token
     repositories:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,19 @@
+kind: pipeline
+name: default
+
+steps:
+- name: trigger  
+  image: plugins/downstream
+  fork: true
+  settings:
+    server: https://zkopru.sifnoc.net
+    token:
+      from_secret: drone_token
+    repositories:
+      - ${DRONE_REPO_OWNER}/stress-test
+
+trigger:
+  repo:
+    - ${DRONE_REPO_OWNER}/zkopru
+  branch:
+    - main


### PR DESCRIPTION
drone CI is supported [downstream build](http://plugins.drone.io/drone-plugins/drone-downstream/) as a plugin(=image)

this config only has a trigger for starting [stress-test](https://github.com/zkopru-network/stress-test) testing pipeline when zkopru main branch updated.