### PR TITLE
chore: layer2 sendTx returns zkTx hash

### DIFF
--- a/packages/zk-wizard/src/zk-wallet-account.ts
+++ b/packages/zk-wizard/src/zk-wallet-account.ts
@@ -748,13 +748,14 @@ export class ZkWalletAccount {
     tx: RawTx
     from?: ZkAccount
     encryptTo?: ZkAddress
-  }): Promise<void> {
+  }): Promise<string> {
     const zkTx = await this.shieldTx({ tx, from, encryptTo })
     const response = await this.sendLayer2Tx(zkTx)
     if (response.status !== 200) {
       await this.unlockUtxos(tx.inflow)
       throw Error(await response.text())
     }
+    return zkTx.hash.toString()
   }
 
   private async deposit(note: Utxo, fee: Fp): Promise<boolean> {

--- a/packages/zk-wizard/src/zk-wallet-account.ts
+++ b/packages/zk-wizard/src/zk-wallet-account.ts
@@ -755,7 +755,7 @@ export class ZkWalletAccount {
       await this.unlockUtxos(tx.inflow)
       throw Error(await response.text())
     }
-    return zkTx.hash.toString()
+    return zkTx.hash().toString()
   }
 
   private async deposit(note: Utxo, fee: Fp): Promise<boolean> {


### PR DESCRIPTION
# What
Change `ZkWalletAccount#sendTx()` to return zkTx hash

# Why
In order for client applications to track transactions which users made in the apps has been included or not.