### PR TITLE
Hotfix/drone trigger

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ steps:
   image: plugins/downstream
   fork: true
   settings:
-    server: https://drone.zkopru.net
+    server: https://drone.zkopru.network
     token:
       from_secret: drone_token
     repositories:

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,19 +1,20 @@
 kind: pipeline
 name: default
 
+clone:
+  disable: true
+
 steps:
 - name: trigger  
   image: plugins/downstream
   fork: true
   settings:
-    server: https://drone.zkopru.network
+    server: https://drone.zkopru.net
     token:
       from_secret: drone_token
     repositories:
-      - ${DRONE_REPO_OWNER}/stress-test
+      - zkopru-network/stress-test
 
 trigger:
-  repo:
-    - ${DRONE_REPO_OWNER}/zkopru
   branch:
     - main


### PR DESCRIPTION
I think is better to make explicit which repository is triggered without using drone reference, `DRONE_REPO_OWNER`.

Just disable fork repo on activation setting on drone server web.

And there is no necessary to clone the zkopru repository for this step.