### PR TITLE
Ipfs gateway fix

### DIFF
--- a/packages/client/src/zkopru-node.ts
+++ b/packages/client/src/zkopru-node.ts
@@ -66,17 +66,15 @@ export default class ZkopruNode {
     )
     // eslint-disable-next-line no-inner-declarations
     async function waitConnection(_provider: any) {
-      return new Promise<void>(async (rs, rj) => {
-        let count = 0
-        for (;;) {
-          if (_provider.connected) return rs()
-          await new Promise(r => setTimeout(r, 200))
-          count += 1
-          if (count > 100) {
-            rj(new Error('Connection timed out'))
-          }
+      let count = 0
+      for (;;) {
+        if (_provider.connected) return
+        await new Promise(r => setTimeout(r, 200))
+        count += 1
+        if (count > 100) {
+          throw new Error('Connection timed out')
         }
-      })
+      }
     }
     provider.connect()
     await waitConnection(provider)

--- a/packages/client/src/zkopru-node.ts
+++ b/packages/client/src/zkopru-node.ts
@@ -66,9 +66,16 @@ export default class ZkopruNode {
     )
     // eslint-disable-next-line no-inner-declarations
     async function waitConnection(_provider: any) {
-      return new Promise<void>(res => {
-        if (_provider.connected) return res()
-        _provider.on('connect', res)
+      return new Promise<void>(async (rs, rj) => {
+        let count = 0
+        for (;;) {
+          if (_provider.connected) return rs()
+          await new Promise(r => setTimeout(r, 200))
+          count += 1
+          if (count > 100) {
+            rj(new Error('Connection timed out'))
+          }
+        }
       })
     }
     provider.connect()

--- a/packages/core/src/node/synchronizer.ts
+++ b/packages/core/src/node/synchronizer.ts
@@ -188,7 +188,7 @@ export class Synchronizer extends EventEmitter {
             .subn(1) // proposal num starts from 0
             .toString(10)
           logger.info(
-            `core/syncrhonizer - processed ${proposalNum}/${layer1ProposedBlocks}`,
+            `core/synchronizer- processed ${proposalNum}/${layer1ProposedBlocks}`,
           )
         })
     }

--- a/packages/zk-wizard/src/zk-wizard.ts
+++ b/packages/zk-wizard/src/zk-wizard.ts
@@ -29,7 +29,7 @@ import {
 
 import { SNARKResult, genSNARK } from './snark'
 
-const IPFS_GATEWAY_HOST = `https://ipfs.tubby.cloud`
+const IPFS_GATEWAY_HOST = `https://ipfs.zkopru.network`
 
 export class ZkWizard {
   path?: string
@@ -113,6 +113,7 @@ export class ZkWizard {
   private async loadKeyPaths(
     nIn: number,
     nOut: number,
+    ipfsGateway: string = IPFS_GATEWAY_HOST,
   ): Promise<{
     wasmPath: string
     zkeyPath: string
@@ -170,14 +171,14 @@ export class ZkWizard {
         {
           logger.info('Downloading vkey')
           const response = await fetch(
-            new URL(vKeyUrlPath, IPFS_GATEWAY_HOST).toString(),
+            new URL(vKeyUrlPath, ipfsGateway).toString(),
           )
           vKey = await response.json()
         }
         if (!fs.existsSync(wasmPath)) {
           logger.info('Downloading wasm')
           const response = await fetch(
-            new URL(wasmUrlPath, IPFS_GATEWAY_HOST).toString(),
+            new URL(wasmUrlPath, ipfsGateway).toString(),
           )
           const filestream = fs.createWriteStream(wasmPath)
           await new Promise((rs, rj) => {
@@ -189,7 +190,7 @@ export class ZkWizard {
         if (!fs.existsSync(zkeyPath)) {
           logger.info('Downloading zkey')
           const response = await fetch(
-            new URL(zKeyUrlPath, IPFS_GATEWAY_HOST).toString(),
+            new URL(zKeyUrlPath, ipfsGateway).toString(),
           )
           const filestream = fs.createWriteStream(zkeyPath)
           await new Promise((rs, rj) => {
@@ -205,13 +206,11 @@ export class ZkWizard {
         }
       }
       // In a web browser, no fs access, store in localstorage
-      const response = await fetch(
-        new URL(vKeyUrlPath, IPFS_GATEWAY_HOST).toString(),
-      )
+      const response = await fetch(new URL(vKeyUrlPath, ipfsGateway).toString())
       const vKey = await response.json()
       return {
-        wasmPath: new URL(wasmUrlPath, IPFS_GATEWAY_HOST).toString(),
-        zkeyPath: new URL(zKeyUrlPath, IPFS_GATEWAY_HOST).toString(),
+        wasmPath: new URL(wasmUrlPath, ipfsGateway).toString(),
+        zkeyPath: new URL(zKeyUrlPath, ipfsGateway).toString(),
         vKey,
       }
     }


### PR DESCRIPTION
Use the Zkopru IPFS gateway by default. Allows a client to pass a custom gateway url.

Fixes a bug with web3 provider connection detection.