### PR TITLE
Index perf

### DIFF
--- a/packages/client/src/zkopru-wallet.ts
+++ b/packages/client/src/zkopru-wallet.ts
@@ -258,29 +258,20 @@ export default class ZkopruWallet {
         proposal: { header: true },
       },
     })
-    const completeDeposits = await this.wallet.db.findMany('Deposit', {
+    const allDeposits = await this.wallet.db.findMany('Deposit', {
       where: {
         ownerAddress: zkAddress,
-        includedIn: { neq: null },
       },
       include: {
         proposal: { header: true },
         utxo: true,
       },
     })
+    const completeDeposits = allDeposits.filter(d => !!d.includedIn)
+    const incompleteDeposits = allDeposits.filter(d => !d.includedIn)
     const pendingDeposits = await this.wallet.db.findMany('PendingDeposit', {
       where: {},
       include: { utxo: true },
-    })
-    const incompleteDeposits = await this.wallet.db.findMany('Deposit', {
-      where: {
-        ownerAddress: zkAddress,
-        includedIn: null,
-      },
-      include: {
-        proposal: { header: true },
-        utxo: true,
-      },
     })
     const withdrawals = await this.wallet.db.findMany('Withdrawal', {
       where: {

--- a/packages/client/src/zkopru-wallet.ts
+++ b/packages/client/src/zkopru-wallet.ts
@@ -273,21 +273,16 @@ export default class ZkopruWallet {
       where: {},
       include: { utxo: true },
     })
-    const withdrawals = await this.wallet.db.findMany('Withdrawal', {
+    const allWithdrawals = await this.wallet.db.findMany('Withdrawal', {
       where: {
         to: this.node.node?.layer1.web3.utils.toChecksumAddress(ethAddress),
-        includedIn: { ne: null },
       },
       include: {
         proposal: { header: true },
       },
     })
-    const incompleteWithdrawals = await this.wallet.db.findMany('Withdrawal', {
-      where: {
-        to: this.node.node?.layer1.web3.utils.toChecksumAddress(ethAddress),
-        includedIn: null,
-      },
-    })
+    const withdrawals = allWithdrawals.filter(w => !!w.includedIn)
+    const incompleteWithdrawals = allWithdrawals.filter(w => !w.includedIn)
     const pending = await this.wallet.db.findMany('PendingTx', {
       where: {
         senderAddress: zkAddress,

--- a/packages/client/tests/rpc.test.ts
+++ b/packages/client/tests/rpc.test.ts
@@ -4,12 +4,12 @@ import Web3 from 'web3'
 import { WebsocketProvider } from 'web3-core'
 import { Container } from 'node-docker-api/lib/container'
 import { FullNode } from '@zkopru/core'
-import Zkopru from '../src'
 import { Coordinator } from '~coordinator'
 import { ZkAccount } from '~account'
 import { sleep, trimHexToLength } from '~utils'
 import { readFromContainer, buildAndGetContainer } from '~utils-docker'
 import { DB, SQLiteConnector, schema } from '~database-node'
+import Zkopru from '../src'
 
 describe('rPC tests', () => {
   const accounts: ZkAccount[] = [

--- a/packages/core/src/context/layer2.ts
+++ b/packages/core/src/context/layer2.ts
@@ -399,7 +399,6 @@ export class L2Chain {
         verified: true,
         hash: blockHashes,
       },
-      orderBy: { proposalNum: 'asc' },
     })
     return canonical.findIndex(p => p.proposalNum < proposalNum) !== -1
   }

--- a/packages/core/src/context/layer2.ts
+++ b/packages/core/src/context/layer2.ts
@@ -394,13 +394,15 @@ export class L2Chain {
       },
     })
     const blockHashes = headers.map(({ hash }) => hash)
+    // TODO: use index when booleans are supported
     const canonical = await this.db.findMany('Proposal', {
       where: {
-        verified: true,
         hash: blockHashes,
       },
     })
-    return canonical.findIndex(p => p.proposalNum < proposalNum) !== -1
+    return (
+      canonical.findIndex(p => p.verified && p.proposalNum < proposalNum) !== -1
+    )
   }
 
   async isValidTx(zkTx: ZkTx): Promise<boolean> {

--- a/packages/core/src/context/layer2.ts
+++ b/packages/core/src/context/layer2.ts
@@ -206,12 +206,24 @@ export class L2Chain {
           .slice(0, 6),
       )}})`,
     )
+    if (massDeposits.length === 0) return []
+    // TODO: actually optimize OR queries
     const massDepositObjects = await this.db.findMany('MassDeposit', {
       where: {
-        OR: massDeposits.map(({ merged, fee }) => ({
-          merged: merged.toString(),
-          fee: fee.toString(),
-        })),
+        ...(massDeposits.length > 1
+          ? {
+              OR: massDeposits.map(({ merged, fee }) => ({
+                merged: merged.toString(),
+                fee: fee.toString(),
+              })),
+            }
+          : {}),
+        ...(massDeposits.length === 1
+          ? {
+              merged: massDeposits[0].merged.toString(),
+              fee: massDeposits[0].fee.toString(),
+            }
+          : {}),
       },
       orderBy: {
         blockNumber: 'asc',

--- a/packages/core/src/node/synchronizer.ts
+++ b/packages/core/src/node/synchronizer.ts
@@ -147,15 +147,25 @@ export class Synchronizer extends EventEmitter {
 
   async updateStatus() {
     logger.trace(`core/synchronizer - Synchronizer::updateStatus()`)
-    const unfetched = await this.db.count('Proposal', {
-      proposalData: null,
+    const unfetched = await this.db.findOne('Proposal', {
+      where: {
+        proposalData: null,
+      },
+      orderBy: {
+        proposalNum: 'desc',
+      },
     })
-    const unprocessed = await this.db.count('Proposal', {
-      verified: null,
-      isUncle: null,
+    const unprocessed = await this.db.findOne('Proposal', {
+      where: {
+        verified: null,
+        isUncle: null,
+      },
+      orderBy: {
+        proposalNum: 'desc',
+      },
     })
-    const haveFetchedAll = unfetched === 0
-    const haveProcessedAll = unprocessed === 0
+    const haveFetchedAll = !unfetched
+    const haveProcessedAll = !unprocessed
     if (!haveFetchedAll) {
       this.setStatus(NetworkStatus.ON_SYNCING)
     } else if (!haveProcessedAll) {

--- a/packages/core/src/validator/offchain/offchain-tx-validator.ts
+++ b/packages/core/src/validator/offchain/offchain-tx-validator.ts
@@ -174,11 +174,11 @@ export class OffchainTxValidator extends OffchainValidatorContext
     // If any of the found header is finalized, it returns true
     const finalized = await this.layer2.db.findMany('Proposal', {
       where: {
-        finalized: true,
         hash: headers.map(h => h.hash),
       },
     })
-    if (finalized.length > 0) return true
+    // TODO: use index when booleans are supported
+    if (finalized.find(p => p.finalized === true)) return true
     // Or check the recent precedent blocks has that utxo tree root
     let currentBlockHash: string = blockHash.toString()
     for (let i = 0; i < this.layer2.config.referenceDepth; i += 1) {

--- a/packages/database/src/connectors/indexed-db.ts
+++ b/packages/database/src/connectors/indexed-db.ts
@@ -352,7 +352,7 @@ export class IndexedDBConnector extends DB {
       findMany: this._findMany.bind(this),
       table,
     })
-    if (+new Date() - start > 50 && typeof window !== undefined)
+    if (+new Date() - start > 50 && typeof window !== 'undefined')
       console.log(
         'query length scan',
         collection,

--- a/packages/database/src/connectors/indexed-db.ts
+++ b/packages/database/src/connectors/indexed-db.ts
@@ -35,7 +35,7 @@ export class IndexedDBConnector extends DB {
   static async create(tables: TableData[]) {
     const schema = constructSchema(tables)
     const connector = new this(schema)
-    connector.db = await openDB(DB_NAME, 23, {
+    connector.db = await openDB(DB_NAME, 24, {
       /**
        * If an index is changed (e.g. same keys different "unique" value) the
        * index will not be updated. If such a case occurs the name should be

--- a/packages/database/src/connectors/indexed-db.ts
+++ b/packages/database/src/connectors/indexed-db.ts
@@ -370,7 +370,14 @@ export class IndexedDBConnector extends DB {
   }
 
   async count(collection: string, where: WhereClause) {
-    return (await this.findMany(collection, { where })).length
+    if (Object.keys(where).length !== 0) {
+      return (await this.findMany(collection, { where })).length
+    }
+    // otherwise just count all the docs in the collection
+    if (!this.db) throw new Error('DB is not initialized')
+    const tx = this.db.transaction(collection, 'readonly')
+    const store = tx.objectStore(collection)
+    return store.count()
   }
 
   async update(collection: string, options: UpdateOptions) {

--- a/packages/database/src/helpers/memory.ts
+++ b/packages/database/src/helpers/memory.ts
@@ -10,7 +10,7 @@ export function validateDocuments(table: SchemaTable, _docs: any | any[]) {
       const row = table.rowsByName[key]
       if (!row) throw new Error('Expected row to exist')
       if (
-        row.default &&
+        typeof row.default !== 'undefined' &&
         (doc[row.name] === undefined || doc[row.name] === null)
       ) {
         Object.assign(defaults, {

--- a/packages/database/src/helpers/shared.ts
+++ b/packages/database/src/helpers/shared.ts
@@ -39,7 +39,7 @@ export async function loadIncluded(
   },
 ) {
   const { models, include, table, findMany } = options
-  if (!include) return
+  if (!include || !models || !models.length) return
   if (!table) throw new Error(`Unable to find table ${collection} in schema`)
   for (const key of Object.keys(include)) {
     const relation = table.relations[key]

--- a/packages/database/src/helpers/sql.ts
+++ b/packages/database/src/helpers/sql.ts
@@ -160,7 +160,7 @@ export function createSql(
   for (const [, row] of Object.entries(table.rows)) {
     for (const doc of docs) {
       if (
-        !row?.default ||
+        typeof row?.default === 'undefined' ||
         (doc[row.name] !== undefined && doc[row.name] !== null)
       )
         // eslint-disable-next-line no-continue

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -80,6 +80,7 @@ export default [
   {
     name: 'Header',
     primaryKey: 'hash',
+    indexes: [{ keys: ['utxoRoot'] }, { keys: ['parentBlock'] }],
     rows: [
       ['hash', 'String'],
       ['proposer', 'String'],
@@ -134,6 +135,12 @@ export default [
   {
     name: 'Proposal',
     primaryKey: 'hash',
+    indexes: [
+      { keys: ['isUncle'] },
+      { keys: ['verified'] },
+      { keys: ['hash'] },
+      { keys: ['hash', 'finalized'] },
+    ],
     rows: [
       ['hash', 'String'],
       ['proposalNum', 'Int', { index: true, optional: true }],
@@ -271,6 +278,11 @@ export default [
   {
     name: 'MassDeposit',
     primaryKey: 'index',
+    indexes: [
+      {
+        keys: ['merged', 'fee'],
+      },
+    ],
     rows: [
       ['index', 'String'],
       ['merged', 'String'],

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -135,13 +135,7 @@ export default [
   {
     name: 'Proposal',
     primaryKey: 'hash',
-    indexes: [
-      { keys: ['isUncle'] },
-      { keys: ['verified'] },
-      { keys: ['hash'] },
-      { keys: ['hash', 'finalized'] },
-      { keys: ['hash', 'verified'] },
-    ],
+    indexes: [{ keys: ['hash'] }],
     rows: [
       ['hash', 'String'],
       ['proposalNum', 'Int', { index: true, optional: true }],

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -140,6 +140,7 @@ export default [
       { keys: ['verified'] },
       { keys: ['hash'] },
       { keys: ['hash', 'finalized'] },
+      { keys: ['hash', 'verified'] },
     ],
     rows: [
       ['hash', 'String'],
@@ -280,7 +281,7 @@ export default [
     primaryKey: 'index',
     indexes: [
       {
-        keys: ['merged', 'fee'],
+        keys: ['merged'],
       },
     ],
     rows: [

--- a/packages/database/src/schema.ts
+++ b/packages/database/src/schema.ts
@@ -320,7 +320,7 @@ export default [
       ['transactionIndex', 'Int'],
       ['logIndex', 'Int'],
       ['blockNumber', 'Int', { index: true }],
-      ['queuedAt', 'String'],
+      ['queuedAt', 'String', { index: true }],
       ['ownerAddress', 'String', { optional: true }],
       ['includedIn', 'String', { optional: true }],
       ['from', 'String', { optional: true }],

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -186,7 +186,7 @@ export function constructSchema(tables: TableData[]): Schema {
       ) {
         // record it as an index, but don't index booleans
         indexes.push({
-          name: `${fullRow.name}-index`,
+          name: `${fullRow.name}-implicit-index`,
           keys: [fullRow.name],
           unique: fullRow.unique,
           optional: fullRow.optional,

--- a/packages/database/tests/indexed-db.test.ts
+++ b/packages/database/tests/indexed-db.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable jest/no-hooks, jest/valid-describe */
+import assert from 'assert'
 import testSchema from './test-schema'
 import { DB, IndexedDBConnector } from '~database/web'
 import FindTests from './database/find'
@@ -27,4 +28,34 @@ describe('indexedDB tests', function(this: any) {
   UpdateTests.bind(this)()
   DeleteTests.bind(this)()
   TransactionTests.bind(this)()
+
+  it('should sort indexed query', async () => {
+    const table = 'IndexTable'
+    for (let x = 0; x < 10; x += 1) {
+      await this.db.create(table, {
+        id: x,
+        id2: 10 - x,
+      })
+    }
+    {
+      const row = await this.db.findOne(table, {
+        where: {
+          id: [0, 1, 2],
+          id2: [10, 9, 8],
+        },
+        orderBy: { id: 'asc' },
+      })
+      assert.equal(row.id, 0)
+    }
+    {
+      const row = await this.db.findOne(table, {
+        where: {
+          id: [0, 1, 2],
+          id2: [10, 9, 8],
+        },
+        orderBy: { id: 'desc' },
+      })
+      assert.equal(row.id, 2)
+    }
+  })
 })

--- a/packages/database/tests/test-schema.ts
+++ b/packages/database/tests/test-schema.ts
@@ -112,4 +112,13 @@ export default [
       ['optionalField', 'String', { optional: true }],
     ],
   },
+  {
+    name: 'IndexTable',
+    primaryKey: 'id',
+    indexes: [{ keys: ['id', 'id2'] }],
+    rows: [
+      ['id', 'Int'],
+      ['id2', 'Int'],
+    ],
+  },
 ] as TableData[]


### PR DESCRIPTION
Uses indexes in scan operations for the indexeddb connector.

This may make #342 unnecessary, a few more queries can be optimized to take hundreds of milliseconds off each block processing time. This would let us avoid downloading, decompressing, and ingesting the state tree from another node.

Time to sync first 200 blocks: 6 minutes 16 seconds
Previous time to sync first 200 blocks: 17 minutes 40 seconds