### PR TITLE
fix over size massDeposits for propose transaction

### DIFF
--- a/packages/coordinator/src/middlewares/default/block-generator.ts
+++ b/packages/coordinator/src/middlewares/default/block-generator.ts
@@ -23,12 +23,13 @@ export class BlockGenerator extends GeneratorBase {
     }
 
     // Calculate consumed bytes and aggregated fee
-    const consumedBytes = 32 // bytes length
+    let consumedBytes = 32 // bytes length
     let aggregatedFee: Fp = Fp.zero
 
     const { layer2 } = this.context.node
     // 1. pick mass deposits
     const pendingMassDeposits = await layer2.getPendingMassDeposits()
+    consumedBytes += pendingMassDeposits.calldataSize
     aggregatedFee = aggregatedFee.add(pendingMassDeposits.totalFee)
 
     // 2. pick transactions

--- a/packages/core/src/context/layer2.ts
+++ b/packages/core/src/context/layer2.ts
@@ -265,6 +265,8 @@ export class L2Chain {
     // 1. pick mass deposits
     const commits: MassDepositSql[] = await this.db.findMany('MassDeposit', {
       where: { includedIn: null },
+      orderBy: { blockNumber: 'asc' },
+      limit: 255
     })
     commits.sort((a, b) => parseInt(a.index, 10) - parseInt(b.index, 10))
     const pendingDeposits = await this.db.findMany('Deposit', {

--- a/packages/core/src/context/layer2.ts
+++ b/packages/core/src/context/layer2.ts
@@ -266,7 +266,7 @@ export class L2Chain {
     const commits: MassDepositSql[] = await this.db.findMany('MassDeposit', {
       where: { includedIn: null },
       orderBy: { blockNumber: 'asc' },
-      limit: 255
+      limit: 255,
     })
     commits.sort((a, b) => parseInt(a.index, 10) - parseInt(b.index, 10))
     const pendingDeposits = await this.db.findMany('Deposit', {


### PR DESCRIPTION
Fix issue #382

Previous Fix https://github.com/zkopru-network/zkopru/pull/368 was one of fault reasons that the coordinator misbehave.
So I rollback codes and replaced `continue` instead `break` in conditions to add massDeposit. the `break` statement makes the coordinator hang on processing slashed block.