### PR TITLE
[fix] add async constructor to zk-wallet and zk-wallet-account

### DIFF
--- a/packages/client/src/zkopru-wallet.ts
+++ b/packages/client/src/zkopru-wallet.ts
@@ -19,6 +19,16 @@ export default class ZkopruWallet {
 
   wallet: ZkWalletAccount
 
+  static async new(
+    node: ZkopruNode,
+    privateKey: Buffer | string,
+  ): Promise<ZkopruWallet> {
+    const wallet = new ZkopruWallet(node, privateKey)
+    // wait until wallet account initialization finished
+    await Promise.all(wallet.wallet.promises)
+    return wallet
+  }
+
   constructor(node: ZkopruNode, privateKey: Buffer | string) {
     this.node = node
     if (!this.node.node) {

--- a/packages/zk-wizard/src/zk-wallet-account.ts
+++ b/packages/zk-wizard/src/zk-wallet-account.ts
@@ -59,6 +59,16 @@ export class ZkWalletAccount {
 
   wizard: ZkWizard
 
+  // store promises created inside constructor
+  promises: Array<Promise<unknown>> = []
+
+  static async new(obj: ZkWalletAccountConfig): Promise<ZkWalletAccount> {
+    const account = new ZkWalletAccount(obj)
+    // wait until all the promises are resolved
+    await Promise.all(account.promises)
+    return account
+  }
+
   constructor(obj: ZkWalletAccountConfig) {
     this.db = obj.node.db
     this.node = obj.node
@@ -80,7 +90,7 @@ export class ZkWalletAccount {
         'Neither privateKey or account supplied for wallet account',
       )
     }
-    this.node.tracker.addAccounts(this.account)
+    this.promises.push(this.node.tracker.addAccounts(this.account))
     this.wizard = new ZkWizard({
       utxoTree: this.node.layer2.grove.utxoTree,
       path: obj.snarkKeyPath,


### PR DESCRIPTION
Currently, ZkWalletAccount has unresolved promise inside its constructor and it's cumbersome to manually wait them resolved outside. For example, the code using ZkWalletAccount has to be check the if the promise returned by `this.node.tracker.addAccounts(account)` resolved or not by checking length of `tracker.transferTrackers` doing something similar to following code.

```ts
const wallet = new ZkWalletAccount(config)
await new Promise((resolve) => {
  // polling to check the transferTrackers length
  setInterval(() => {
    if (wallet.node.tracker.transferTrackers === 1)  {
      clearInterval(); resolve()
    }, 500)
})

// now wallet is initialized properly.
```

Instead of doing this, implement async constructor and wait it initialized. and this can be used like this

```ts
const wallet = await ZkWalletAccount.new(config)
```
