### PR TITLE
create database file with name by each network or contract

### DIFF
--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -60,6 +60,7 @@ export type NodeConfig = {
   address?: string
   bootstrap?: boolean
   websocket?: string
+  chainId?: number
   rpcUrl?: string
   accounts?: ZkAccount[]
 }

--- a/packages/client/src/zkopru-node.ts
+++ b/packages/client/src/zkopru-node.ts
@@ -40,7 +40,8 @@ export default class ZkopruNode {
 
   private async initDB(...args: any[]) {
     if (!this._db) {
-      this._db = await this.connectorType.create(schema, ...args)
+      const databaseName = `zkopru-${this.config.chainId}-${this.config.address?.slice(2,)}`
+      this._db = await this.connectorType.create(schema, databaseName, ...args)
     }
   }
 
@@ -79,6 +80,8 @@ export default class ZkopruNode {
     provider.connect()
     await waitConnection(provider)
     await new Promise(r => setTimeout(r, 1000))
+    const web3 = new Web3(provider)
+    this.config.chainId = await web3.eth.getChainId()
     this.node = await FullNode.new({
       address: this.config.address as string,
       provider,

--- a/packages/database/src/connectors/indexed-db.ts
+++ b/packages/database/src/connectors/indexed-db.ts
@@ -32,10 +32,10 @@ export class IndexedDBConnector extends DB {
     this.schema = schema
   }
 
-  static async create(tables: TableData[]) {
+  static async create(tables: TableData[], databaseName?: string) {
     const schema = constructSchema(tables)
     const connector = new this(schema)
-    connector.db = await openDB(DB_NAME, 28, {
+    connector.db = await openDB(databaseName || DB_NAME, 28, {
       /**
        * If an index is changed (e.g. same keys different "unique" value) the
        * index will not be updated. If such a case occurs the name should be


### PR DESCRIPTION
Currently, only one database file, the name 'zkopru', for using zkopru web wallet.

We need databases for each network and each zkopru contract in indexedDB.

To be like this
<img src="https://user-images.githubusercontent.com/10276359/172107176-2bd06423-5b68-4a18-b82a-c7781525274b.png" width="600" />

related branch [wallet - feat/network-selector](https://github.com/sifnoc/wallet/tree/feat/network-selector)
