### PR TITLE
Fix docker compose for alpine release v3.16

### DIFF
--- a/dockerfiles/Cli.dockerfile
+++ b/dockerfiles/Cli.dockerfile
@@ -25,7 +25,7 @@ COPY ./packages/zk-wizard/package.json /proj/packages/zk-wizard/package.json
 COPY ./yarn.lock /proj/yarn.lock
 
 # install build tools
-RUN apk add --no-cache --virtual .gyp \
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.10/main --virtual .gyp \
     python2 \
     make \
     g++ \
@@ -55,6 +55,7 @@ COPY ./packages/cli/wallet.*.json /proj/packages/cli/
 ENV GOROOT /usr/lib/go
 ENV GOPATH /go
 ENV PATH /go/bin:$PATH
+RUN go env -w GO111MODULE=off
 RUN mkdir -p ${GOPATH}/src ${GOPATH}/bin \
     && go get github.com/sorenisanerd/gotty
 

--- a/dockerfiles/Cli.dockerfile
+++ b/dockerfiles/Cli.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:16-alpine3.16
 RUN apk add --no-cache git go sqlite postgresql-client netcat-openbsd tmux musl-dev
 RUN mkdir -p /usr/share/man/man1 \
     && mkdir -p /usr/share/man/man7

--- a/dockerfiles/Coordinator.dockerfile
+++ b/dockerfiles/Coordinator.dockerfile
@@ -17,7 +17,7 @@ COPY ./packages/tree/package.json /proj/packages/tree/package.json
 COPY ./packages/utils/package.json /proj/packages/utils/package.json
 COPY ./packages/zk-wizard/package.json /proj/packages/zk-wizard/package.json
 
-RUN apk add --no-cache --virtual .gyp \
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.10/main --virtual .gyp \
     python2 \
     make \
     g++ \

--- a/dockerfiles/Coordinator.dockerfile
+++ b/dockerfiles/Coordinator.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:16-alpine3.16
 RUN apk add --no-cache git
 WORKDIR /proj
 

--- a/dockerfiles/Playground.dockerfile
+++ b/dockerfiles/Playground.dockerfile
@@ -7,7 +7,7 @@ RUN git clone --depth=1 https://github.com/zkopru-network/zkopru
 WORKDIR /proj/zkopru
 
 # install build tools temporarily
-RUN apk add --no-cache --virtual .gyp \
+RUN apk add --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/v3.10/main --virtual .gyp \
         python3 \
         python2 \
         make \

--- a/dockerfiles/Playground.dockerfile
+++ b/dockerfiles/Playground.dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:16-alpine3.16
 RUN apk add --no-cache git sqlite
 WORKDIR /proj
 


### PR DESCRIPTION
Based on the new alpine release, the package repo deprecates python2. Therefore we need to specify specific repository version in docker file when installing python2 by `apk add python2`.
In addition to that, go get seems not working without env of `GO111MODULE=off`.

https://alpinelinux.org/posts/Alpine-3.16.0-released.html