### PR TITLE
Fix in UtxoDeposit listener

### DIFF
--- a/packages/client/src/node.ts
+++ b/packages/client/src/node.ts
@@ -24,7 +24,8 @@ export default {
 }
 
 export { ZkAccount } from '@zkopru/account'
-export { UtxoStatus } from '@zkopru/transaction'
+export { UtxoStatus, Note, Utxo } from '@zkopru/transaction'
+export { Fp } from '@zkopru/babyjubjub'
 
 export { default as ZkopruNode } from './zkopru-node'
 export { default as ZkopruWallet } from './zkopru-wallet'

--- a/packages/core/src/node/synchronizer.ts
+++ b/packages/core/src/node/synchronizer.ts
@@ -667,7 +667,8 @@ export class Synchronizer extends EventEmitter {
           )
           if (!owner) {
             // skip storing Deposit details
-            return
+            // eslint-disable-next-line no-continue
+            continue
           }
           const salt = Fp.from(returnValues.salt)
           const note = new Note(owner, salt, {


### PR DESCRIPTION
I think I have found an issue in the UtxoDeposit listener function in the [synchronizer](https://github.com/zkopru-network/zkopru/blob/57ceb6a8f1b0f4d75feb451cc7fe935a76e14b5c/packages/core/src/node/synchronizer.ts).

In the `listenDepositUtxos` function, while processing the [existing blocks](https://github.com/zkopru-network/zkopru/blob/57ceb6a8f1b0f4d75feb451cc7fe935a76e14b5c/packages/core/src/node/synchronizer.ts#L646), if the owner of a `DepositUtxo` event is not one of the `addresses` being tracked, it exits the function (`return` statement). This prevent processing of all further events and blocks. 

Moreover it prevents the [code for attaching a subscriber](https://github.com/zkopru-network/zkopru/blob/57ceb6a8f1b0f4d75feb451cc7fe935a76e14b5c/packages/core/src/node/synchronizer.ts#L697) to the future events being executed. 

This PR changed the `return` statement to `continue` so only that particular event is skipped.