### PR TITLE
Typos

### DIFF
--- a/packages/contracts/contracts/zkopru/controllers/UserInteractable.sol
+++ b/packages/contracts/contracts/zkopru/controllers/UserInteractable.sol
@@ -46,7 +46,7 @@ contract UserInteractable is Storage {
     );
 
     /**
-     * @notice Users can use zkopru network by submitting a new homomorphically hiden note.
+     * @notice Users can use zkopru network by submitting a new homomorphically hidden note.
      * @param spendingPubKey P = poseidon(p*G, N) https://github.com/zkopru-network/zkopru/issues/34#issuecomment-666988505
      * @param salt 254bit salt for the privacy
      * @param eth Amount of Ether to deposit

--- a/packages/database/src/connectors/indexed-db.ts
+++ b/packages/database/src/connectors/indexed-db.ts
@@ -556,7 +556,7 @@ export class IndexedDBConnector extends DB {
         })
         tx = this.db.transaction(storesUnique, 'readwrite')
         // explicitly cast the start function because TS cannot determine that it's
-        // set above. The body of a promise is executed sychronously so start will
+        // set above. The body of a promise is executed synchronously so start will
         // be assigned at this point
         ;(start as Function)()
         await Promise.all([promise, tx.done])


### PR DESCRIPTION
Fix: Typos in Comments Corrected

What Changed
Fixed typographical errors in comments to improve clarity and professionalism.

Why These Changes Were Made
Correcting typos enhances the readability and clarity of the codebase, ensuring a more polished and professional appearance.

Additional Notes
These changes are limited to comments only and do not impact the code's functionality.